### PR TITLE
Rename module and types. Add "Key-Value" qualifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,17 +55,17 @@ Using a bitemporal database allows you to offload management of temporal applica
 // On writes: WithValidTime, WithEndValidTime
 // On reads: AsOfValidTime, AsOfTransactionTime
 type DB interface {
-	// Get data by id (as of optional valid and transaction times).
-	Get(id string, opts ...ReadOpt) (*Document, error)
+	// Get data by key (as of optional valid and transaction times).
+	Get(key string, opts ...ReadOpt) (*Document, error)
 	// List all data (as of optional valid and transaction times).
 	List(opts ...ReadOpt) ([]*Document, error)
 	// Set stores attributes (with optional start and end valid time).
-	Set(id string, attributes Attributes, opts ...WriteOpt) error
+	Set(key string, attributes Attributes, opts ...WriteOpt) error
 	// Delete removes attributes (with optional start and end valid time).
-	Delete(id string, opts ...WriteOpt) error
+	Delete(key string, opts ...WriteOpt) error
 
 	// History returns versions by descending end transaction time, descending end valid time
-	History(id string) ([]*Document, error)
+	History(key string) ([]*Document, error)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ Because every fact in a bitemporal database has these two dimensions, it enables
 ```go
 // We initialize a DB and start using it like an ordinary key-value store.
 db, err := memory.NewDB()
-err := db.Set("Bob/balance", Attributes{"dollars": 100})
+err := db.Set("Bob/balance", 100)
 doc, err := db.Get("Bob/balance")
 err := db.Delete("Alice/balance")
 // and so on...
 
 // We later learn that Bob had a temporary pending charge we missed from Dec 30 to Jan 3. (VT start = Dec 30, VT end = Jan 3)
 // Retroactively record it! This does not change his balance today nor does it destroy any history we had about that period.
-err := db.Set("Bob/balance", Attributes{"dollars": 90}, WithValidTime(dec30), WithEndValidTime(jan3))
+err := db.Set("Bob/balance", 90, WithValidTime(dec30), WithEndValidTime(jan3))
 
 // We can at any point seamlessly ask questions about the real world past AND database record past!
 // "What was Bob's balance on Jan 1 as best we knew on Jan 8?" (VT = Jan 1, TT = Jan 8)
@@ -51,17 +51,17 @@ Using a bitemporal database allows you to offload management of temporal applica
 ```go
 // DB for bitemporal data.
 //
-// Temporal control options
-// On writes: WithValidTime, WithEndValidTime
-// On reads: AsOfValidTime, AsOfTransactionTime
+// Temporal control options.
+// On writes: WithValidTime, WithEndValidTime.
+// On reads: AsOfValidTime, AsOfTransactionTime.
 type DB interface {
 	// Get data by key (as of optional valid and transaction times).
 	Get(key string, opts ...ReadOpt) (*Document, error)
 	// List all data (as of optional valid and transaction times).
 	List(opts ...ReadOpt) ([]*Document, error)
-	// Set stores attributes (with optional start and end valid time).
-	Set(key string, attributes Attributes, opts ...WriteOpt) error
-	// Delete removes attributes (with optional start and end valid time).
+	// Set stores value (with optional start and end valid time).
+	Set(key string, value Value, opts ...WriteOpt) error
+	// Delete removes value (with optional start and end valid time).
 	Delete(key string, opts ...WriteOpt) error
 
 	// History returns versions by descending end transaction time, descending end valid time

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# bitemporal ⌛
+# bitempura ⌛
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/elh/bitemporal.svg)](https://pkg.go.dev/github.com/elh/bitemporal)
-[![Build Status](https://github.com/elh/bitemporal/actions/workflows/go.yml/badge.svg?branch=main)](https://github.com/elh/bitemporal/actions/workflows/go.yml?query=branch%3Amain)
+[![Go Reference](https://pkg.go.dev/badge/github.com/elh/bitempura.svg)](https://pkg.go.dev/github.com/elh/bitempura)
+[![Build Status](https://github.com/elh/bitempura/actions/workflows/go.yml/badge.svg?branch=main)](https://github.com/elh/bitempura/actions/workflows/go.yml?query=branch%3Amain)
 
 Building intuition about [bitemporal databases](https://en.wikipedia.org/wiki/Bitemporal_Modeling) by building (a toy) one for myself.
 
@@ -27,7 +27,7 @@ versions, err := db.History("Bob/balance")
 
 Using a bitemporal database allows you to offload management of temporal application data (valid time) and data versions (transaction time) from your code and onto infrastructure. This provides a universal "time travel" capability across models in the database. Adopting bitemporality is proactive because by the time you realize you need to update (or have already updated) data, it may be too late. Context may already be lost or painful to reconstruct manually.
 
-See [in memory reference implementation](https://github.com/elh/bitemporal/blob/main/memory/db.go)
+See [in memory reference implementation](https://github.com/elh/bitempura/blob/main/memory/db.go)
 
 ### Design
 
@@ -55,4 +55,4 @@ type DB interface {
 }
 ```
 
-See [TODO](https://github.com/elh/bitemporal/blob/main/TODO.md)
+See [TODO](https://github.com/elh/bitempura/blob/main/TODO.md)

--- a/README.md
+++ b/README.md
@@ -52,32 +52,36 @@ Using a bitemporal database allows you to offload management of temporal applica
 // DB for bitemporal data.
 //
 // Temporal control options.
-// On writes: WithValidTime, WithEndValidTime.
-// On reads: AsOfValidTime, AsOfTransactionTime.
+// ReadOpt's: AsOfValidTime, AsOfTransactionTime.
+// WriteOpt's: WithValidTime, WithEndValidTime.
 type DB interface {
 	// Get data by key (as of optional valid and transaction times).
-	Get(key string, opts ...ReadOpt) (*VersionedValue, error)
+	Get(key string, opts ...ReadOpt) (*VersionedKV, error)
 	// List all data (as of optional valid and transaction times).
-	List(opts ...ReadOpt) ([]*VersionedValue, error)
+	List(opts ...ReadOpt) ([]*VersionedKV, error)
 	// Set stores value (with optional start and end valid time).
 	Set(key string, value Value, opts ...WriteOpt) error
 	// Delete removes value (with optional start and end valid time).
 	Delete(key string, opts ...WriteOpt) error
 
-	// History returns versions by descending end transaction time, descending end valid time
-	History(key string) ([]*VersionedValue, error)
+	// History returns all versioned key-values for key by descending end transaction time, descending end valid time.
+	History(key string) ([]*VersionedKV, error)
 }
 
-// VersionedValue is the core data type. Transaction and valid time starts are inclusive and ends are exclusive
-type VersionedValue struct {
+// VersionedKV is a transaction time and valid time versioned key-value. Transaction and valid time starts are inclusive
+// and ends are exclusive. No two VersionedKVs for the same key can overlap both transaction time and valid time.
+type VersionedKV struct {
 	Key   string
 	Value Value
 
-	TxTimeStart    time.Time
-	TxTimeEnd      *time.Time
-	ValidTimeStart time.Time
-	ValidTimeEnd   *time.Time
+	TxTimeStart    time.Time  // inclusive
+	TxTimeEnd      *time.Time // exclusive
+	ValidTimeStart time.Time  // inclusive
+	ValidTimeEnd   *time.Time // exclusive
 }
+
+// Value is the user-controlled data associated with a key (and valid and transaction time information) in the database.
+type Value interface{}
 ```
 
 <br />

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-# bitempura ⌛
+# bitempura ⌛... ⏳!
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/elh/bitempura.svg)](https://pkg.go.dev/github.com/elh/bitempura)
 [![Build Status](https://github.com/elh/bitempura/actions/workflows/go.yml/badge.svg?branch=main)](https://github.com/elh/bitempura/actions/workflows/go.yml?query=branch%3Amain)
 
-Building intuition about [bitemporal databases](https://en.wikipedia.org/wiki/Bitemporal_Modeling) by building (a toy) one for myself.
+**Bitempura.DB is a [bitemporal](https://en.wikipedia.org/wiki/Bitemporal_Modeling) key-value database with an [in-memory reference implementation](https://github.com/elh/bitempura/blob/main/memory/db.go).**
+
+### Bitemporality
 
 Temporal databases model time as a core aspect of storing and querying data. A bitemporal database is one that supports these orthogonal axes.
 * **Valid time**: When the fact was *true* in the real world. This is the *application domain's* notion of time.
@@ -17,17 +19,16 @@ doc, err := db.Find("Bob/balance", AsOfValidTime(jan1), AsOfTransactionTime(jan8
 // But what was it on Jan 1 as best we now know? (VT = Jan 1, TT = now)
 doc2, err := db.Find("Bob/balance", AsOfValidTime(jan1))
 
-// We just learned that Bob had a temporary charge from Dec 30 to Jan 3 (VT start = Dec 30, VT end = Jan 3).
+// We just learned that Bob had a temporary charge from Dec 30 to Jan 3. (VT start = Dec 30, VT end = Jan 3)
 // Retroactively add it.
 err := db.Put("Bob/balance", Attributes{"dollars": 90}, WithValidTime(dec30), WithEndValidTime(jan3))
 
-// And let's double check all of our transactions and known states
+// And let's double check all of our transactions and known states.
 versions, err := db.History("Bob/balance")
 ```
+*See [full exampes](https://github.com/elh/bitempura/blob/main/memory/db_examples_test.go)
 
-Using a bitemporal database allows you to offload management of temporal application data (valid time) and data versions (transaction time) from your code and onto infrastructure. This provides a universal "time travel" capability across models in the database. Adopting bitemporality is proactive because by the time you realize you need to update (or have already updated) data, it may be too late. Context may already be lost or painful to reconstruct manually.
-
-See [in memory reference implementation](https://github.com/elh/bitempura/blob/main/memory/db.go)
+Using a bitemporal database allows you to offload management of temporal application data (valid time) and data versions (transaction time) from your code and onto infrastructure. This provides a universal "time travel" capability across models in the database. Adopting these capabilities proactively is valuable because by the time you realize you need to update (or have already updated) data, it may be too late. Context may already be lost or painful to reconstruct manually.
 
 ### Design
 
@@ -55,4 +56,12 @@ type DB interface {
 }
 ```
 
-See [TODO](https://github.com/elh/bitempura/blob/main/TODO.md)
+### Author
+
+I'm learning about [bitemporal databases](https://en.wikipedia.org/wiki/Bitemporal_Modeling) and thought the best way to build intuition about their internal design was by building a simple one for myself. I am primarily interesting in:
+* Creating materials to teach others
+* Building tools to gracefully extend existing SQL databases with bitemporality
+
+Bitempura was the name of my time travelling shrimp. RIP 2049-2021. 🍤
+
+See [TODO](https://github.com/elh/bitempura/blob/main/TODO.md) for more.

--- a/README.md
+++ b/README.md
@@ -17,22 +17,22 @@ Because every fact in a bitemporal database has these two dimensions, it enables
 ```go
 // We initialize a DB and start using it like an ordinary key-value store.
 db, err := memory.NewDB()
-err := db.Put("Bob/balance", Attributes{"dollars": 100})
-doc, err := db.Find("Bob/balance")
+err := db.Set("Bob/balance", Attributes{"dollars": 100})
+doc, err := db.Get("Bob/balance")
 err := db.Delete("Alice/balance")
 // and so on...
 
 // We later learn that Bob had a temporary pending charge we missed from Dec 30 to Jan 3. (VT start = Dec 30, VT end = Jan 3)
 // Retroactively record it! This does not change his balance today nor does it destroy any history we had about that period.
-err := db.Put("Bob/balance", Attributes{"dollars": 90}, WithValidTime(dec30), WithEndValidTime(jan3))
+err := db.Set("Bob/balance", Attributes{"dollars": 90}, WithValidTime(dec30), WithEndValidTime(jan3))
 
 // We can at any point seamlessly ask questions about the real world past AND database record past!
 // "What was Bob's balance on Jan 1 as best we knew on Jan 8?" (VT = Jan 1, TT = Jan 8)
-doc, err := db.Find("Bob/balance", AsOfValidTime(jan1), AsOfTransactionTime(jan8))
+doc, err := db.Get("Bob/balance", AsOfValidTime(jan1), AsOfTransactionTime(jan8))
 
 // More time passes and more corrections are made... When trying to make sense of what happened last month, we can ask again:
 // "But what was it on Jan 1 as best we now know?" (VT = Jan 1, TT = now)
-doc2, err := db.Find("Bob/balance", AsOfValidTime(jan1))
+doc2, err := db.Get("Bob/balance", AsOfValidTime(jan1))
 
 // And while we are at it, let's double check all of our transactions and known states for Bob's balance.
 versions, err := db.History("Bob/balance")
@@ -55,12 +55,12 @@ Using a bitemporal database allows you to offload management of temporal applica
 // On writes: WithValidTime, WithEndValidTime
 // On reads: AsOfValidTime, AsOfTransactionTime
 type DB interface {
-	// Find data by id (as of optional valid and transaction times).
-	Find(id string, opts ...ReadOpt) (*Document, error)
+	// Get data by id (as of optional valid and transaction times).
+	Get(id string, opts ...ReadOpt) (*Document, error)
 	// List all data (as of optional valid and transaction times).
 	List(opts ...ReadOpt) ([]*Document, error)
-	// Put stores attributes (with optional start and end valid time).
-	Put(id string, attributes Attributes, opts ...WriteOpt) error
+	// Set stores attributes (with optional start and end valid time).
+	Set(id string, attributes Attributes, opts ...WriteOpt) error
 	// Delete removes attributes (with optional start and end valid time).
 	Delete(id string, opts ...WriteOpt) error
 

--- a/README.md
+++ b/README.md
@@ -5,32 +5,45 @@
 
 **Bitempura.DB is a [bitemporal](https://en.wikipedia.org/wiki/Bitemporal_Modeling) key-value database with an [in-memory reference implementation](https://github.com/elh/bitempura/blob/main/memory/db.go).**
 
-### Bitemporality
+<br />
+
+## Bitemporality
 
 Temporal databases model time as a core aspect of storing and querying data. A bitemporal database is one that supports these orthogonal axes.
 * **Valid time**: When the fact was *true* in the real world. This is the *application domain's* notion of time.
 * **Transaction time**: When the fact was *recorded* in the database. This is the *system's* notion of time.
 
-Because every fact in a bitemporal database has these two dimensions, it enables use cases like...
+Because every fact in a bitemporal database has these two dimensions, it enables use cases like this:
 ```go
-// What was Bob's balance on Jan 1 as best we knew on Jan 8? (VT = Jan 1, TT = Jan 8)
-doc, err := db.Find("Bob/balance", AsOfValidTime(jan1), AsOfTransactionTime(jan8))
+// We initialize a DB and start using it like an ordinary key-value store.
+db, err := memory.NewDB()
+err := db.Put("Bob/balance", Attributes{"dollars": 100})
+doc, err := db.Find("Bob/balance")
+err := db.Delete("Alice/balance")
+// and so on...
 
-// But what was it on Jan 1 as best we now know? (VT = Jan 1, TT = now)
-doc2, err := db.Find("Bob/balance", AsOfValidTime(jan1))
-
-// We just learned that Bob had a temporary charge from Dec 30 to Jan 3. (VT start = Dec 30, VT end = Jan 3)
-// Retroactively add it.
+// We later learn that Bob had a temporary pending charge we missed from Dec 30 to Jan 3. (VT start = Dec 30, VT end = Jan 3)
+// Retroactively record it! This does not change his balance today nor does it destroy any history we had about that period.
 err := db.Put("Bob/balance", Attributes{"dollars": 90}, WithValidTime(dec30), WithEndValidTime(jan3))
 
-// And let's double check all of our transactions and known states.
+// We can at any point seamlessly ask questions about the real world past AND database record past!
+// "What was Bob's balance on Jan 1 as best we knew on Jan 8?" (VT = Jan 1, TT = Jan 8)
+doc, err := db.Find("Bob/balance", AsOfValidTime(jan1), AsOfTransactionTime(jan8))
+
+// More time passes and more corrections are made... When trying to make sense of what happened last month, we can ask again:
+// "But what was it on Jan 1 as best we now know?" (VT = Jan 1, TT = now)
+doc2, err := db.Find("Bob/balance", AsOfValidTime(jan1))
+
+// And while we are at it, let's double check all of our transactions and known states for Bob's balance.
 versions, err := db.History("Bob/balance")
 ```
 *See [full exampes](https://github.com/elh/bitempura/blob/main/memory/db_examples_test.go)
 
 Using a bitemporal database allows you to offload management of temporal application data (valid time) and data versions (transaction time) from your code and onto infrastructure. This provides a universal "time travel" capability across models in the database. Adopting these capabilities proactively is valuable because by the time you realize you need to update (or have already updated) data, it may be too late. Context may already be lost or painful to reconstruct manually.
 
-### Design
+<br />
+
+## Design
 
 * Initial DB API is inspired by XTDB (and Datomic).
 * Record layout is inspired by Snodgrass' SQL implementations.
@@ -56,12 +69,15 @@ type DB interface {
 }
 ```
 
-### Author
+<br />
 
-I'm learning about [bitemporal databases](https://en.wikipedia.org/wiki/Bitemporal_Modeling) and thought the best way to build intuition about their internal design was by building a simple one for myself. I am primarily interesting in:
-* Creating materials to teach others
-* Building tools to gracefully extend existing SQL databases with bitemporality
+## Author
 
-Bitempura was the name of my time travelling shrimp. RIP 2049-2021. 🍤
+I'm learning about [bitemporal databases](https://en.wikipedia.org/wiki/Bitemporal_Modeling) and thought the best way to build intuition about their internal design was by building a simple one for myself. My goals are:
+* Making this a viable, standalone lib
+* Creating artifacts to teach others about temporal data
+* Launching off this to new tools for gracefully extending existing SQL databases with bitemporality
+
+Bitempura was the name of my time travelling shrimp. RIP 2049-2022. 🦐
 
 See [TODO](https://github.com/elh/bitempura/blob/main/TODO.md) for more.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/elh/bitempura.svg)](https://pkg.go.dev/github.com/elh/bitempura)
 [![Build Status](https://github.com/elh/bitempura/actions/workflows/go.yml/badge.svg?branch=main)](https://github.com/elh/bitempura/actions/workflows/go.yml?query=branch%3Amain)
 
-**Bitempura.DB is a [bitemporal](https://en.wikipedia.org/wiki/Bitemporal_Modeling) key-value database with an [in-memory reference implementation](https://github.com/elh/bitempura/blob/main/memory/db.go).**
+**Bitempura.DB is a simple, [in-memory](https://github.com/elh/bitempura/blob/main/memory/db.go) [bitemporal](https://en.wikipedia.org/wiki/Bitemporal_Modeling) key-value database.**
 
 <br />
 
@@ -45,9 +45,6 @@ Using a bitemporal database allows you to offload management of temporal applica
 
 ## Design
 
-* Initial DB API is inspired by XTDB (and Datomic).
-* Record layout is inspired by Snodgrass' SQL implementations.
-
 ```go
 // DB for bitemporal data.
 //
@@ -84,12 +81,15 @@ type VersionedKV struct {
 type Value interface{}
 ```
 
+* DB interface is inspired by XTDB (and Datomic).
+* Storage model is inspired by Snodgrass' SQL implementations.
+
 <br />
 
 ## Author
 
 I'm learning about [bitemporal databases](https://en.wikipedia.org/wiki/Bitemporal_Modeling) and thought the best way to build intuition about their internal design was by building a simple one for myself. My goals are:
-* Making this a viable, standalone lib
+* Sharing a viable, standalone key-value store lib
 * Creating artifacts to teach others about temporal data
 * Launching off this to new tools for gracefully extending existing SQL databases with bitemporality
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 ## TODO:
-- [x] [API v1 done](https://github.com/elh/bitempura/blob/main/db.go). [In memory implementation](https://github.com/elh/bitempura/blob/main/memory/db.go)
+- [x] [API v1 done](https://github.com/elh/bitempura/blob/main/db.go). [In-memory implementation](https://github.com/elh/bitempura/blob/main/memory/db.go)
     - [x] Find
     - [x] List
     - [x] Put

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,8 @@
 ## TODO:
 - [x] [API v1 done](https://github.com/elh/bitempura/blob/main/db.go). [In-memory implementation](https://github.com/elh/bitempura/blob/main/memory/db.go)
-    - [x] Find
+    - [x] Get
     - [x] List
-    - [x] Put
+    - [x] Set
     - [x] Delete
 - [x] [XTDB, Robinhood example tests pass](https://github.com/elh/bitempura/blob/main/memory/db_examples_test.go)
 - [x] Split out in-memory implementation

--- a/TODO.md
+++ b/TODO.md
@@ -7,14 +7,18 @@
 - [x] [XTDB, Robinhood example tests pass](https://github.com/elh/bitempura/blob/main/memory/db_examples_test.go)
 - [x] Split out in-memory implementation
 - [x] History API?
-- [ ] Separate "db" and "storage" models. first pass was blending XTDB APIs with Snodgrass style records and things are getting muddled.
-    - Storage layer will inform choices for querying ability at DB layer.
-- [ ] Should data read and write APIs return tx time and valid time context at all?
-- [ ] Consider common option handling, common repo test harness later. (Split out in-memory implementation follow on)
-- [ ] SQL backed implementation
-- [ ] Document new intuition about mutations + the 2D time graph
+    - [ ] ReadOpt's for History
+- [ ] Thread safe writes
+- [ ] Exported ReadOpt and WriteOpt handling
+- [ ] Exported DB test harness
+- [ ] Visualizations. Interactive?
+
+Candidates
+- [ ] Write about new intuition about mutations + the 2D time graph
     - [ ] Valid time management as a custom "version rule"?
     - [ ] "Domain time"?
     - [ ] Explore geographical map idea. 2D of data + transaction time => 3 dimensions?
+- [ ] Separate "db" and "storage" models? first pass was blending XTDB APIs with Snodgrass style records and things are getting muddled. Storage layer will inform choices for querying ability at DB layer.
+    - [ ] Should data read and write APIs return tx time and valid time context at all?
+- [ ] SQL backed implementation?
 - [ ] Consider Datomic accumulate and retract event style. Immutable storage layer?
-- [ ] Visualizations. Interactive?

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,10 @@
 ## TODO:
-- [x] [API v1 done](https://github.com/elh/bitemporal/blob/main/db.go). [In memory implementation](https://github.com/elh/bitemporal/blob/main/memory/db.go)
+- [x] [API v1 done](https://github.com/elh/bitempura/blob/main/db.go). [In memory implementation](https://github.com/elh/bitempura/blob/main/memory/db.go)
     - [x] Find
     - [x] List
     - [x] Put
     - [x] Delete
-- [x] [XTDB, Robinhood example tests pass](https://github.com/elh/bitemporal/blob/main/memory/db_examples_test.go)
+- [x] [XTDB, Robinhood example tests pass](https://github.com/elh/bitempura/blob/main/memory/db_examples_test.go)
 - [x] Split out in-memory implementation
 - [x] History API?
 - [ ] Separate "db" and "storage" models. first pass was blending XTDB APIs with Snodgrass style records and things are getting muddled.

--- a/db.go
+++ b/db.go
@@ -10,13 +10,13 @@ import (
 // On writes: WithValidTime, WithEndValidTime.
 // On reads: AsOfValidTime, AsOfTransactionTime.
 type DB interface {
-	// Get document by key as of specified times.
+	// Get data by key (as of optional valid and transaction times).
 	Get(key string, opts ...ReadOpt) (*Document, error)
-	// List all documents as of specified times.
+	// List all data (as of optional valid and transaction times).
 	List(opts ...ReadOpt) ([]*Document, error)
-	// Set stores attributes with optional configured valid times.
-	Set(key string, attributes Attributes, opts ...WriteOpt) error
-	// Delete removes attributes with optional configured valid times.
+	// Set stores value (with optional start and end valid time).
+	Set(key string, value Value, opts ...WriteOpt) error
+	// Delete removes value (with optional start and end valid time).
 	Delete(key string, opts ...WriteOpt) error
 
 	// History returns versions by descending end transaction time, descending end valid time

--- a/db.go
+++ b/db.go
@@ -10,17 +10,17 @@ import (
 // On writes: WithValidTime, WithEndValidTime.
 // On reads: AsOfValidTime, AsOfTransactionTime.
 type DB interface {
-	// Get document by id as of specified times.
-	Get(id string, opts ...ReadOpt) (*Document, error)
+	// Get document by key as of specified times.
+	Get(key string, opts ...ReadOpt) (*Document, error)
 	// List all documents as of specified times.
 	List(opts ...ReadOpt) ([]*Document, error)
 	// Set stores attributes with optional configured valid times.
-	Set(id string, attributes Attributes, opts ...WriteOpt) error
+	Set(key string, attributes Attributes, opts ...WriteOpt) error
 	// Delete removes attributes with optional configured valid times.
-	Delete(id string, opts ...WriteOpt) error
+	Delete(key string, opts ...WriteOpt) error
 
 	// History returns versions by descending end transaction time, descending end valid time
-	History(id string) ([]*Document, error)
+	History(key string) ([]*Document, error)
 }
 
 type WriteOptions struct {

--- a/db.go
+++ b/db.go
@@ -1,4 +1,4 @@
-package bitemporal
+package bitempura
 
 import (
 	"time"

--- a/db.go
+++ b/db.go
@@ -11,16 +11,16 @@ import (
 // On reads: AsOfValidTime, AsOfTransactionTime.
 type DB interface {
 	// Get data by key (as of optional valid and transaction times).
-	Get(key string, opts ...ReadOpt) (*Document, error)
+	Get(key string, opts ...ReadOpt) (*VersionedValue, error)
 	// List all data (as of optional valid and transaction times).
-	List(opts ...ReadOpt) ([]*Document, error)
+	List(opts ...ReadOpt) ([]*VersionedValue, error)
 	// Set stores value (with optional start and end valid time).
 	Set(key string, value Value, opts ...WriteOpt) error
 	// Delete removes value (with optional start and end valid time).
 	Delete(key string, opts ...WriteOpt) error
 
 	// History returns versions by descending end transaction time, descending end valid time
-	History(key string) ([]*Document, error)
+	History(key string) ([]*VersionedValue, error)
 }
 
 type WriteOptions struct {

--- a/db.go
+++ b/db.go
@@ -7,20 +7,20 @@ import (
 // DB for bitemporal data.
 //
 // Temporal control options.
-// On writes: WithValidTime, WithEndValidTime.
-// On reads: AsOfValidTime, AsOfTransactionTime.
+// ReadOpt's: AsOfValidTime, AsOfTransactionTime.
+// WriteOpt's: WithValidTime, WithEndValidTime.
 type DB interface {
 	// Get data by key (as of optional valid and transaction times).
-	Get(key string, opts ...ReadOpt) (*VersionedValue, error)
+	Get(key string, opts ...ReadOpt) (*VersionedKV, error)
 	// List all data (as of optional valid and transaction times).
-	List(opts ...ReadOpt) ([]*VersionedValue, error)
+	List(opts ...ReadOpt) ([]*VersionedKV, error)
 	// Set stores value (with optional start and end valid time).
 	Set(key string, value Value, opts ...WriteOpt) error
 	// Delete removes value (with optional start and end valid time).
 	Delete(key string, opts ...WriteOpt) error
 
-	// History returns versions by descending end transaction time, descending end valid time
-	History(key string) ([]*VersionedValue, error)
+	// History returns all versioned key-values for key by descending end transaction time, descending end valid time.
+	History(key string) ([]*VersionedKV, error)
 }
 
 type WriteOptions struct {

--- a/db.go
+++ b/db.go
@@ -10,12 +10,12 @@ import (
 // On writes: WithValidTime, WithEndValidTime.
 // On reads: AsOfValidTime, AsOfTransactionTime.
 type DB interface {
-	// Find document by id as of specified times.
-	Find(id string, opts ...ReadOpt) (*Document, error)
+	// Get document by id as of specified times.
+	Get(id string, opts ...ReadOpt) (*Document, error)
 	// List all documents as of specified times.
 	List(opts ...ReadOpt) ([]*Document, error)
-	// Put stores attributes with optional configured valid times.
-	Put(id string, attributes Attributes, opts ...WriteOpt) error
+	// Set stores attributes with optional configured valid times.
+	Set(id string, attributes Attributes, opts ...WriteOpt) error
 	// Delete removes attributes with optional configured valid times.
 	Delete(id string, opts ...WriteOpt) error
 

--- a/doc.go
+++ b/doc.go
@@ -1,2 +1,3 @@
-// Package bitemporal contains experiments with bitemporal data
-package bitemporal
+// Package bitempura contains experiments with bitemporal data.
+// It defines an interface for bitemporal key-value databases.
+package bitempura

--- a/document.go
+++ b/document.go
@@ -5,22 +5,23 @@ import (
 	"time"
 )
 
-// VersionedValue is the core data type. Transaction and valid time starts are inclusive and ends are exclusive
-type VersionedValue struct {
+// VersionedKV is a transaction time and valid time versioned key-value. Transaction and valid time starts are inclusive
+// and ends are exclusive. No two VersionedKVs for the same key can overlap both transaction time and valid time.
+type VersionedKV struct {
 	Key   string
 	Value Value
 
-	TxTimeStart    time.Time
-	TxTimeEnd      *time.Time
-	ValidTimeStart time.Time
-	ValidTimeEnd   *time.Time
+	TxTimeStart    time.Time  // inclusive
+	TxTimeEnd      *time.Time // exclusive
+	ValidTimeStart time.Time  // inclusive
+	ValidTimeEnd   *time.Time // exclusive
 }
 
 // Value is the user-controlled data associated with a key (and valid and transaction time information) in the database.
 type Value interface{}
 
-// Validate a versioned value
-func (d *VersionedValue) Validate() error {
+// Validate a versioned key-value
+func (d *VersionedKV) Validate() error {
 	if d.Key == "" {
 		return errors.New("key is required")
 	}

--- a/document.go
+++ b/document.go
@@ -14,11 +14,11 @@ type Document struct {
 	TxTimeEnd      *time.Time
 	ValidTimeStart time.Time
 	ValidTimeEnd   *time.Time
-	Attributes     Attributes
+	Value          Value
 }
 
-// Attributes is the user-controlled data tracked by the database.
-type Attributes map[string]interface{}
+// Value is the user-controlled data associated with a key (and valid and transaction time information) in the database.
+type Value interface{}
 
 // Validate a document
 func (d *Document) Validate() error {
@@ -46,9 +46,6 @@ func (d *Document) Validate() error {
 		if !d.ValidTimeStart.Before(*d.ValidTimeEnd) {
 			return errors.New("valid time start must be before end")
 		}
-	}
-	if d.Attributes == nil {
-		return errors.New("attributes cannot be null")
 	}
 	return nil
 }

--- a/document.go
+++ b/document.go
@@ -9,7 +9,7 @@ import (
 type Document struct {
 	// TODO(elh): Separate "db" model and "storage" model. The breakdown of "documents" and assignment of tx times is
 	// an internal detail that is implementation specific
-	ID             string
+	Key            string
 	TxTimeStart    time.Time
 	TxTimeEnd      *time.Time
 	ValidTimeStart time.Time
@@ -22,8 +22,8 @@ type Attributes map[string]interface{}
 
 // Validate a document
 func (d *Document) Validate() error {
-	if d.ID == "" {
-		return errors.New("id is required")
+	if d.Key == "" {
+		return errors.New("key is required")
 	}
 	if d.TxTimeStart.IsZero() {
 		return errors.New("transaction time start cannot be zero value")

--- a/document.go
+++ b/document.go
@@ -1,4 +1,4 @@
-package bitemporal
+package bitempura
 
 import (
 	"errors"

--- a/document.go
+++ b/document.go
@@ -5,23 +5,22 @@ import (
 	"time"
 )
 
-// Document is the core data type. Transaction and valid time starts are inclusive and ends are exclusive
-type Document struct {
-	// TODO(elh): Separate "db" model and "storage" model. The breakdown of "documents" and assignment of tx times is
-	// an internal detail that is implementation specific
-	Key            string
+// VersionedValue is the core data type. Transaction and valid time starts are inclusive and ends are exclusive
+type VersionedValue struct {
+	Key   string
+	Value Value
+
 	TxTimeStart    time.Time
 	TxTimeEnd      *time.Time
 	ValidTimeStart time.Time
 	ValidTimeEnd   *time.Time
-	Value          Value
 }
 
 // Value is the user-controlled data associated with a key (and valid and transaction time information) in the database.
 type Value interface{}
 
-// Validate a document
-func (d *Document) Validate() error {
+// Validate a versioned value
+func (d *VersionedValue) Validate() error {
 	if d.Key == "" {
 		return errors.New("key is required")
 	}

--- a/errors.go
+++ b/errors.go
@@ -1,4 +1,4 @@
-package bitemporal
+package bitempura
 
 import "errors"
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/elh/bitemporal
+module github.com/elh/bitempura
 
 go 1.17
 

--- a/memory/db.go
+++ b/memory/db.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"time"
 
-	bt "github.com/elh/bitemporal"
+	bt "github.com/elh/bitempura"
 )
 
 var _ bt.DB = (*DB)(nil)

--- a/memory/db.go
+++ b/memory/db.go
@@ -15,7 +15,7 @@ var _ bt.DB = (*DB)(nil)
 //
 // The database may optionally be seeded with Document "versions". No two Documents for the same id may overlap both
 // transaction time and valid time. Transaction times (which normally default to now) may be controlled with SetNow.
-func NewDB(documents []*bt.Document) (*DB, error) {
+func NewDB(documents ...*bt.Document) (*DB, error) {
 	db := &DB{documents: map[string][]*bt.Document{}}
 	for _, d := range documents {
 		if err := d.Validate(); err != nil {

--- a/memory/db.go
+++ b/memory/db.go
@@ -34,8 +34,8 @@ type DB struct {
 	documents map[string][]*bt.Document // id -> all "versions" of the document
 }
 
-// Find data by id (as of optional valid and transaction times).
-func (db *DB) Find(id string, opts ...bt.ReadOpt) (*bt.Document, error) {
+// Get data by id (as of optional valid and transaction times).
+func (db *DB) Get(id string, opts ...bt.ReadOpt) (*bt.Document, error) {
 	options := db.handleReadOpts(opts)
 
 	vs, ok := db.documents[id]
@@ -62,8 +62,8 @@ func (db *DB) List(opts ...bt.ReadOpt) ([]*bt.Document, error) {
 	return ret, nil
 }
 
-// Put stores attributes (with optional start and end valid time).
-func (db *DB) Put(id string, attributes bt.Attributes, opts ...bt.WriteOpt) error {
+// Set stores attributes (with optional start and end valid time).
+func (db *DB) Set(id string, attributes bt.Attributes, opts ...bt.WriteOpt) error {
 	return db.updateRecords(id, attributes, opts...)
 }
 
@@ -91,7 +91,7 @@ func (db *DB) History(id string) ([]*bt.Document, error) {
 	return out, nil
 }
 
-// common logic of Put and Delete. handling of existing records and "overhand" is the same. If newAttributes is nil,
+// common logic of Set and Delete. handling of existing records and "overhand" is the same. If newAttributes is nil,
 // none is created (Delete case).
 func (db *DB) updateRecords(id string, newAttributes bt.Attributes, opts ...bt.WriteOpt) error {
 	options, now, err := db.handleWriteOpts(opts)
@@ -130,7 +130,7 @@ func (db *DB) updateRecords(id string, newAttributes bt.Attributes, opts ...bt.W
 		}
 	}
 
-	// add newAttributes for Put API, nop for Delete API
+	// add newAttributes for Set API, nop for Delete API
 	if newAttributes != nil {
 		newDoc := &bt.Document{
 			ID:             id,
@@ -167,7 +167,7 @@ func (db *DB) handleWriteOpts(opts []bt.WriteOpt) (options *bt.WriteOptions, now
 		opt(options)
 	}
 
-	// validate write option times. this is relevant for Delete even if Put is validated at resource level
+	// validate write option times. this is relevant for Delete even if Set is validated at resource level
 	if options.EndValidTime != nil && !options.EndValidTime.After(options.ValidTime) {
 		return nil, time.Time{}, errors.New("valid time start must be before end")
 	}

--- a/memory/db.go
+++ b/memory/db.go
@@ -131,7 +131,7 @@ func (db *DB) update(key string, value bt.Value, isDelete bool, opts ...bt.Write
 		}
 	}
 
-	// add value for Set API, add nothing for Delete API
+	// add value for Set, add nothing for Delete
 	if !isDelete {
 		newV := &bt.VersionedKV{
 			Key:            key,

--- a/memory/db_examples_test.go
+++ b/memory/db_examples_test.go
@@ -19,7 +19,7 @@ import (
 // > the investigator will step through this sequence to monitor a set of suspects. These events will arrive in an
 // > undetermined chronological order based on how and when each checkpoint is able to manually relay the information.
 func TestTXDBCrimeInvestigationExample(t *testing.T) {
-	db, err := memory.NewDB(nil)
+	db, err := memory.NewDB()
 	require.Nil(t, err)
 
 	// -------------------- Day 0 --------------------
@@ -300,7 +300,7 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 // see https://robinhood.engineering/tracking-temporal-data-at-robinhood-b62291644a31
 // > At Robinhood, accounting is a central part of our business...
 func TestRobinhoodExample(t *testing.T) {
-	db, err := memory.NewDB(nil)
+	db, err := memory.NewDB()
 	require.Nil(t, err)
 
 	// Say you deposit $100 in your account on 3/14.

--- a/memory/db_examples_test.go
+++ b/memory/db_examples_test.go
@@ -3,8 +3,8 @@ package memory_test
 import (
 	"testing"
 
-	. "github.com/elh/bitemporal"
-	"github.com/elh/bitemporal/memory"
+	. "github.com/elh/bitempura"
+	"github.com/elh/bitempura/memory"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/memory/db_examples_test.go
+++ b/memory/db_examples_test.go
@@ -195,7 +195,7 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	out, err := db.List(AsOfValidTime(day2), AsOfTransactionTime(day3))
 	require.Nil(t, err)
 	require.Len(t, out, 3)
-	outByKey := sortDocumentsByKey(out)
+	outByKey := sortValuesByKey(out)
 	assert.Equal(t, "p2", outByKey[0].Key)
 	assert.Equal(t, Doc{
 		"entry-pt":       "SFO",
@@ -223,7 +223,7 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	out, err = db.List(AsOfValidTime(day2))
 	require.Nil(t, err)
 	require.Len(t, out, 4)
-	outByKey = sortDocumentsByKey(out)
+	outByKey = sortValuesByKey(out)
 	assert.Equal(t, "p1", outByKey[0].Key) // this was not known in the original query. p1 info was recorded TT = day 4
 	assert.Equal(t, Doc{
 		"entry-pt":       "NY",
@@ -253,7 +253,7 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	out, err = db.List()
 	require.Nil(t, err)
 	require.Len(t, out, 7)
-	outByKey = sortDocumentsByKey(out)
+	outByKey = sortValuesByKey(out)
 	assert.Equal(t, "p1", outByKey[0].Key)
 	assert.Equal(t, Doc{
 		"entry-pt":       "LA",

--- a/memory/db_examples_test.go
+++ b/memory/db_examples_test.go
@@ -27,12 +27,12 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	// was recorded entering :LA.
 	day0 := mustParseTime(shortForm, "2018-12-31")
 	db.SetNow(day0)
-	require.Nil(t, db.Put("p2", Attributes{
+	require.Nil(t, db.Set("p2", Attributes{
 		"entry-pt":       "SFO",
 		"arrival-time":   day0,
 		"departure-time": nil,
 	}))
-	require.Nil(t, db.Put("p3", Attributes{
+	require.Nil(t, db.Set("p3", Attributes{
 		"entry-pt":       "LA",
 		"arrival-time":   day0,
 		"departure-time": nil,
@@ -45,7 +45,7 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	// A single event arrives on Day 2 showing Person 4 arriving at :NY:
 	day2 := day0.AddDate(0, 0, 2)
 	db.SetNow(day2)
-	require.Nil(t, db.Put("p4", Attributes{
+	require.Nil(t, db.Set("p4", Attributes{
 		"entry-pt":       "NY",
 		"arrival-time":   day2,
 		"departure-time": nil,
@@ -56,7 +56,7 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	// document using the Day 3 valid time:
 	day3 := day0.AddDate(0, 0, 3)
 	db.SetNow(day3)
-	require.Nil(t, db.Put("p4", Attributes{
+	require.Nil(t, db.Set("p4", Attributes{
 		"entry-pt":       "NY",
 		"arrival-time":   day2,
 		"departure-time": day3,
@@ -67,7 +67,7 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	// showing that Person 1 entered :NY on Day 0 which must ingest using the Day 0 valid time #inst "2018-12-31":
 	day4 := day0.AddDate(0, 0, 4)
 	db.SetNow(day4)
-	require.Nil(t, db.Put("p1", Attributes{
+	require.Nil(t, db.Set("p1", Attributes{
 		"entry-pt":       "NY",
 		"arrival-time":   day0,
 		"departure-time": nil,
@@ -75,19 +75,19 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 		WithValidTime(day0)))
 	// We then receive an event showing that Person 1 departed from :NY on Day 3, so again we ingest this document using
 	// the corresponding Day 3 valid time:
-	require.Nil(t, db.Put("p1", Attributes{
+	require.Nil(t, db.Set("p1", Attributes{
 		"entry-pt":       "NY",
 		"arrival-time":   day0,
 		"departure-time": day3,
 	},
 		WithValidTime(day3)))
 	// Finally, we receive two events relating to Day 4, which can be ingested using the current valid time:
-	require.Nil(t, db.Put("p1", Attributes{
+	require.Nil(t, db.Set("p1", Attributes{
 		"entry-pt":       "LA",
 		"arrival-time":   day4,
 		"departure-time": nil,
 	}))
-	require.Nil(t, db.Put("p3", Attributes{
+	require.Nil(t, db.Set("p3", Attributes{
 		"entry-pt":       "LA",
 		"arrival-time":   day0,
 		"departure-time": day4,
@@ -98,7 +98,7 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	// :SFO on Day 5.
 	day5 := day0.AddDate(0, 0, 5)
 	db.SetNow(day5)
-	require.Nil(t, db.Put("p2", Attributes{
+	require.Nil(t, db.Set("p2", Attributes{
 		"entry-pt":       "SFO",
 		"arrival-time":   day0,
 		"departure-time": day5,
@@ -113,13 +113,13 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	// on Day 7, which is how the previous error was noticed.
 	day7 := day0.AddDate(0, 0, 7)
 	db.SetNow(day7)
-	require.Nil(t, db.Put("p3", Attributes{
+	require.Nil(t, db.Set("p3", Attributes{
 		"entry-pt":       "LA",
 		"arrival-time":   day0,
 		"departure-time": nil,
 	},
 		WithValidTime(day4)))
-	require.Nil(t, db.Put("p3", Attributes{
+	require.Nil(t, db.Set("p3", Attributes{
 		"entry-pt":       "LA",
 		"arrival-time":   day0,
 		"departure-time": day7,
@@ -130,12 +130,12 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	// country again.
 	day8 := day0.AddDate(0, 0, 8)
 	db.SetNow(day8)
-	require.Nil(t, db.Put("p3", Attributes{
+	require.Nil(t, db.Set("p3", Attributes{
 		"entry-pt":       "SFO",
 		"arrival-time":   day8,
 		"departure-time": nil,
 	}))
-	require.Nil(t, db.Put("p4", Attributes{
+	require.Nil(t, db.Set("p4", Attributes{
 		"entry-pt":       "LA",
 		"arrival-time":   day8,
 		"departure-time": nil,
@@ -145,7 +145,7 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	// On Day 9 we learn that Person 3 also departed on Day 8.
 	day9 := day0.AddDate(0, 0, 9)
 	db.SetNow(day9)
-	require.Nil(t, db.Put("p3", Attributes{
+	require.Nil(t, db.Set("p3", Attributes{
 		"entry-pt":       "SFO",
 		"arrival-time":   day8,
 		"departure-time": day8,
@@ -155,7 +155,7 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	// A single document arrives showing that Person 5 entered at :LA earlier that day.
 	day10 := day0.AddDate(0, 0, 10)
 	db.SetNow(day10)
-	require.Nil(t, db.Put("p5", Attributes{
+	require.Nil(t, db.Set("p5", Attributes{
 		"entry-pt":       "LA",
 		"arrival-time":   day10,
 		"departure-time": nil,
@@ -165,7 +165,7 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	// Similarly to the previous day, a single document arrives showing that Person 7 entered at :NY earlier that day.
 	day11 := day0.AddDate(0, 0, 11)
 	db.SetNow(day11)
-	require.Nil(t, db.Put("p7", Attributes{
+	require.Nil(t, db.Set("p7", Attributes{
 		"entry-pt":       "NY",
 		"arrival-time":   day11,
 		"departure-time": nil,
@@ -175,7 +175,7 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	// Finally, on Day 12 we learn that Person 6 entered at :NY that same day.
 	day12 := day0.AddDate(0, 0, 12)
 	db.SetNow(day11)
-	require.Nil(t, db.Put("p6", Attributes{
+	require.Nil(t, db.Set("p6", Attributes{
 		"entry-pt":       "NY",
 		"arrival-time":   day12,
 		"departure-time": nil,
@@ -306,14 +306,14 @@ func TestRobinhoodExample(t *testing.T) {
 	// Say you deposit $100 in your account on 3/14.
 	mar14 := mustParseTime(shortForm, "2021-03-14")
 	db.SetNow(mar14)
-	require.Nil(t, db.Put("user-1", Attributes{
+	require.Nil(t, db.Set("user-1", Attributes{
 		"cash-balance": 100,
 		"description":  "Deposit", // description of last event??
 	}))
 	// On 3/20, you purchase 1 share of ABC stock at $25.
 	mar20 := mustParseTime(shortForm, "2021-03-20")
 	db.SetNow(mar20)
-	require.Nil(t, db.Put("user-1", Attributes{
+	require.Nil(t, db.Set("user-1", Attributes{
 		"cash-balance": 75,
 		"description":  "Stock Purchase",
 	}))
@@ -321,7 +321,7 @@ func TestRobinhoodExample(t *testing.T) {
 	// actually $10.
 	mar21 := mustParseTime(shortForm, "2021-03-21")
 	db.SetNow(mar21)
-	require.Nil(t, db.Put("user-1", Attributes{
+	require.Nil(t, db.Set("user-1", Attributes{
 		"cash-balance": 90,
 		"description":  "Price Improvement",
 	},
@@ -329,12 +329,12 @@ func TestRobinhoodExample(t *testing.T) {
 
 	// compacting...
 	findBalance := func(opts ...ReadOpt) interface{} {
-		ret, err := db.Find("user-1", opts...)
+		ret, err := db.Get("user-1", opts...)
 		require.Nil(t, err)
 		return ret.Attributes["cash-balance"]
 	}
-	expectErrFindBalance := func(opts ...ReadOpt) {
-		_, err := db.Find("user-1", opts...)
+	expectErrGetBalance := func(opts ...ReadOpt) {
+		_, err := db.Get("user-1", opts...)
 		require.NotNil(t, err)
 	}
 
@@ -347,7 +347,7 @@ func TestRobinhoodExample(t *testing.T) {
 	// VT=now, TT=3/14. before stock purchase
 	assert.Equal(t, 100, findBalance(AsOfTransactionTime(mar14)))
 	// VT=now, TT=3/13. before any record
-	expectErrFindBalance(AsOfTransactionTime(mar13))
+	expectErrGetBalance(AsOfTransactionTime(mar13))
 	// VT=3/14, TT=now. 3/14 balance as of now
 	assert.Equal(t, 100, findBalance(AsOfValidTime(mar14)))
 	// VT=3/14, TT=3/20. 3/14 balance before price correction
@@ -355,5 +355,5 @@ func TestRobinhoodExample(t *testing.T) {
 	// VT=3/14, TT=3/14. 3/14 balance before stock purchase
 	assert.Equal(t, 100, findBalance(AsOfTransactionTime(mar14), AsOfValidTime(mar14)))
 	// VT=3/14, TT=3/13. 3/14 balance before any record
-	expectErrFindBalance(AsOfTransactionTime(mar13), AsOfValidTime(mar14))
+	expectErrGetBalance(AsOfTransactionTime(mar13), AsOfValidTime(mar14))
 }

--- a/memory/db_examples_test.go
+++ b/memory/db_examples_test.go
@@ -193,25 +193,25 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	out, err := db.List(AsOfValidTime(day2), AsOfTransactionTime(day3))
 	require.Nil(t, err)
 	require.Len(t, out, 3)
-	outByID := sortDocumentsByID(out)
-	assert.Equal(t, "p2", outByID[0].ID)
+	outByKey := sortDocumentsByKey(out)
+	assert.Equal(t, "p2", outByKey[0].Key)
 	assert.Equal(t, Attributes{
 		"entry-pt":       "SFO",
 		"arrival-time":   day0,
 		"departure-time": nil,
-	}, outByID[0].Attributes)
-	assert.Equal(t, "p3", outByID[1].ID)
+	}, outByKey[0].Attributes)
+	assert.Equal(t, "p3", outByKey[1].Key)
 	assert.Equal(t, Attributes{
 		"entry-pt":       "LA",
 		"arrival-time":   day0,
 		"departure-time": nil,
-	}, outByID[1].Attributes)
-	assert.Equal(t, "p4", outByID[2].ID)
+	}, outByKey[1].Attributes)
+	assert.Equal(t, "p4", outByKey[2].Key)
 	assert.Equal(t, Attributes{
 		"entry-pt":       "NY",
 		"arrival-time":   day2,
 		"departure-time": nil,
-	}, outByID[2].Attributes)
+	}, outByKey[2].Attributes)
 
 	// -------------------- My extra tests --------------------
 	// elh: this was actually quite simple. the times are so early that they disregard so many edits. let's do a few
@@ -221,79 +221,79 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	out, err = db.List(AsOfValidTime(day2))
 	require.Nil(t, err)
 	require.Len(t, out, 4)
-	outByID = sortDocumentsByID(out)
-	assert.Equal(t, "p1", outByID[0].ID) // this was not known in the original query. p1 info was recorded TT = day 4
+	outByKey = sortDocumentsByKey(out)
+	assert.Equal(t, "p1", outByKey[0].Key) // this was not known in the original query. p1 info was recorded TT = day 4
 	assert.Equal(t, Attributes{
 		"entry-pt":       "NY",
 		"arrival-time":   day0,
 		"departure-time": nil,
-	}, outByID[0].Attributes)
-	assert.Equal(t, "p2", outByID[1].ID)
+	}, outByKey[0].Attributes)
+	assert.Equal(t, "p2", outByKey[1].Key)
 	assert.Equal(t, Attributes{
 		"entry-pt":       "SFO",
 		"arrival-time":   day0,
 		"departure-time": nil,
-	}, outByID[1].Attributes)
-	assert.Equal(t, "p3", outByID[2].ID)
+	}, outByKey[1].Attributes)
+	assert.Equal(t, "p3", outByKey[2].Key)
 	assert.Equal(t, Attributes{
 		"entry-pt":       "LA",
 		"arrival-time":   day0,
 		"departure-time": nil,
-	}, outByID[2].Attributes)
-	assert.Equal(t, "p4", outByID[3].ID)
+	}, outByKey[2].Attributes)
+	assert.Equal(t, "p4", outByKey[3].Key)
 	assert.Equal(t, Attributes{
 		"entry-pt":       "NY",
 		"arrival-time":   day2,
 		"departure-time": nil,
-	}, outByID[3].Attributes)
+	}, outByKey[3].Attributes)
 
 	// state of db at now (VT = day 12, TT = day 12)
 	out, err = db.List()
 	require.Nil(t, err)
 	require.Len(t, out, 7)
-	outByID = sortDocumentsByID(out)
-	assert.Equal(t, "p1", outByID[0].ID)
+	outByKey = sortDocumentsByKey(out)
+	assert.Equal(t, "p1", outByKey[0].Key)
 	assert.Equal(t, Attributes{
 		"entry-pt":       "LA",
 		"arrival-time":   day4,
 		"departure-time": nil,
-	}, outByID[0].Attributes)
-	assert.Equal(t, "p2", outByID[1].ID)
+	}, outByKey[0].Attributes)
+	assert.Equal(t, "p2", outByKey[1].Key)
 	assert.Equal(t, Attributes{
 		"entry-pt":       "SFO",
 		"arrival-time":   day0,
 		"departure-time": day5,
-	}, outByID[1].Attributes)
-	assert.Equal(t, "p3", outByID[2].ID)
+	}, outByKey[1].Attributes)
+	assert.Equal(t, "p3", outByKey[2].Key)
 	assert.Equal(t, Attributes{
 		"entry-pt":       "SFO",
 		"arrival-time":   day8,
 		"departure-time": day8,
-	}, outByID[2].Attributes)
-	assert.Equal(t, "p4", outByID[3].ID)
+	}, outByKey[2].Attributes)
+	assert.Equal(t, "p4", outByKey[3].Key)
 	assert.Equal(t, Attributes{
 		"entry-pt":       "LA",
 		"arrival-time":   day8,
 		"departure-time": nil,
-	}, outByID[3].Attributes)
-	assert.Equal(t, "p5", outByID[4].ID)
+	}, outByKey[3].Attributes)
+	assert.Equal(t, "p5", outByKey[4].Key)
 	assert.Equal(t, Attributes{
 		"entry-pt":       "LA",
 		"arrival-time":   day10,
 		"departure-time": nil,
-	}, outByID[4].Attributes)
-	assert.Equal(t, "p6", outByID[5].ID)
+	}, outByKey[4].Attributes)
+	assert.Equal(t, "p6", outByKey[5].Key)
 	assert.Equal(t, Attributes{
 		"entry-pt":       "NY",
 		"arrival-time":   day12,
 		"departure-time": nil,
-	}, outByID[5].Attributes)
-	assert.Equal(t, "p7", outByID[6].ID)
+	}, outByKey[5].Attributes)
+	assert.Equal(t, "p7", outByKey[6].Key)
 	assert.Equal(t, Attributes{
 		"entry-pt":       "NY",
 		"arrival-time":   day11,
 		"departure-time": nil,
-	}, outByID[6].Attributes)
+	}, outByKey[6].Attributes)
 }
 
 // Robinhood Eng blog > Tracking Temporal Data at Robinhood

--- a/memory/db_examples_test.go
+++ b/memory/db_examples_test.go
@@ -22,17 +22,19 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	db, err := memory.NewDB()
 	require.Nil(t, err)
 
+	type Doc map[string]interface{}
+
 	// -------------------- Day 0 --------------------
 	// The first document shows that Person 2 was recorded entering via :SFO and the second document shows that Person 3
 	// was recorded entering :LA.
 	day0 := mustParseTime(shortForm, "2018-12-31")
 	db.SetNow(day0)
-	require.Nil(t, db.Set("p2", Attributes{
+	require.Nil(t, db.Set("p2", Doc{
 		"entry-pt":       "SFO",
 		"arrival-time":   day0,
 		"departure-time": nil,
 	}))
-	require.Nil(t, db.Set("p3", Attributes{
+	require.Nil(t, db.Set("p3", Doc{
 		"entry-pt":       "LA",
 		"arrival-time":   day0,
 		"departure-time": nil,
@@ -45,7 +47,7 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	// A single event arrives on Day 2 showing Person 4 arriving at :NY:
 	day2 := day0.AddDate(0, 0, 2)
 	db.SetNow(day2)
-	require.Nil(t, db.Set("p4", Attributes{
+	require.Nil(t, db.Set("p4", Doc{
 		"entry-pt":       "NY",
 		"arrival-time":   day2,
 		"departure-time": nil,
@@ -56,7 +58,7 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	// document using the Day 3 valid time:
 	day3 := day0.AddDate(0, 0, 3)
 	db.SetNow(day3)
-	require.Nil(t, db.Set("p4", Attributes{
+	require.Nil(t, db.Set("p4", Doc{
 		"entry-pt":       "NY",
 		"arrival-time":   day2,
 		"departure-time": day3,
@@ -67,7 +69,7 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	// showing that Person 1 entered :NY on Day 0 which must ingest using the Day 0 valid time #inst "2018-12-31":
 	day4 := day0.AddDate(0, 0, 4)
 	db.SetNow(day4)
-	require.Nil(t, db.Set("p1", Attributes{
+	require.Nil(t, db.Set("p1", Doc{
 		"entry-pt":       "NY",
 		"arrival-time":   day0,
 		"departure-time": nil,
@@ -75,19 +77,19 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 		WithValidTime(day0)))
 	// We then receive an event showing that Person 1 departed from :NY on Day 3, so again we ingest this document using
 	// the corresponding Day 3 valid time:
-	require.Nil(t, db.Set("p1", Attributes{
+	require.Nil(t, db.Set("p1", Doc{
 		"entry-pt":       "NY",
 		"arrival-time":   day0,
 		"departure-time": day3,
 	},
 		WithValidTime(day3)))
 	// Finally, we receive two events relating to Day 4, which can be ingested using the current valid time:
-	require.Nil(t, db.Set("p1", Attributes{
+	require.Nil(t, db.Set("p1", Doc{
 		"entry-pt":       "LA",
 		"arrival-time":   day4,
 		"departure-time": nil,
 	}))
-	require.Nil(t, db.Set("p3", Attributes{
+	require.Nil(t, db.Set("p3", Doc{
 		"entry-pt":       "LA",
 		"arrival-time":   day0,
 		"departure-time": day4,
@@ -98,7 +100,7 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	// :SFO on Day 5.
 	day5 := day0.AddDate(0, 0, 5)
 	db.SetNow(day5)
-	require.Nil(t, db.Set("p2", Attributes{
+	require.Nil(t, db.Set("p2", Doc{
 		"entry-pt":       "SFO",
 		"arrival-time":   day0,
 		"departure-time": day5,
@@ -113,13 +115,13 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	// on Day 7, which is how the previous error was noticed.
 	day7 := day0.AddDate(0, 0, 7)
 	db.SetNow(day7)
-	require.Nil(t, db.Set("p3", Attributes{
+	require.Nil(t, db.Set("p3", Doc{
 		"entry-pt":       "LA",
 		"arrival-time":   day0,
 		"departure-time": nil,
 	},
 		WithValidTime(day4)))
-	require.Nil(t, db.Set("p3", Attributes{
+	require.Nil(t, db.Set("p3", Doc{
 		"entry-pt":       "LA",
 		"arrival-time":   day0,
 		"departure-time": day7,
@@ -130,12 +132,12 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	// country again.
 	day8 := day0.AddDate(0, 0, 8)
 	db.SetNow(day8)
-	require.Nil(t, db.Set("p3", Attributes{
+	require.Nil(t, db.Set("p3", Doc{
 		"entry-pt":       "SFO",
 		"arrival-time":   day8,
 		"departure-time": nil,
 	}))
-	require.Nil(t, db.Set("p4", Attributes{
+	require.Nil(t, db.Set("p4", Doc{
 		"entry-pt":       "LA",
 		"arrival-time":   day8,
 		"departure-time": nil,
@@ -145,7 +147,7 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	// On Day 9 we learn that Person 3 also departed on Day 8.
 	day9 := day0.AddDate(0, 0, 9)
 	db.SetNow(day9)
-	require.Nil(t, db.Set("p3", Attributes{
+	require.Nil(t, db.Set("p3", Doc{
 		"entry-pt":       "SFO",
 		"arrival-time":   day8,
 		"departure-time": day8,
@@ -155,7 +157,7 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	// A single document arrives showing that Person 5 entered at :LA earlier that day.
 	day10 := day0.AddDate(0, 0, 10)
 	db.SetNow(day10)
-	require.Nil(t, db.Set("p5", Attributes{
+	require.Nil(t, db.Set("p5", Doc{
 		"entry-pt":       "LA",
 		"arrival-time":   day10,
 		"departure-time": nil,
@@ -165,7 +167,7 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	// Similarly to the previous day, a single document arrives showing that Person 7 entered at :NY earlier that day.
 	day11 := day0.AddDate(0, 0, 11)
 	db.SetNow(day11)
-	require.Nil(t, db.Set("p7", Attributes{
+	require.Nil(t, db.Set("p7", Doc{
 		"entry-pt":       "NY",
 		"arrival-time":   day11,
 		"departure-time": nil,
@@ -175,7 +177,7 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	// Finally, on Day 12 we learn that Person 6 entered at :NY that same day.
 	day12 := day0.AddDate(0, 0, 12)
 	db.SetNow(day11)
-	require.Nil(t, db.Set("p6", Attributes{
+	require.Nil(t, db.Set("p6", Doc{
 		"entry-pt":       "NY",
 		"arrival-time":   day12,
 		"departure-time": nil,
@@ -195,23 +197,23 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	require.Len(t, out, 3)
 	outByKey := sortDocumentsByKey(out)
 	assert.Equal(t, "p2", outByKey[0].Key)
-	assert.Equal(t, Attributes{
+	assert.Equal(t, Doc{
 		"entry-pt":       "SFO",
 		"arrival-time":   day0,
 		"departure-time": nil,
-	}, outByKey[0].Attributes)
+	}, outByKey[0].Value)
 	assert.Equal(t, "p3", outByKey[1].Key)
-	assert.Equal(t, Attributes{
+	assert.Equal(t, Doc{
 		"entry-pt":       "LA",
 		"arrival-time":   day0,
 		"departure-time": nil,
-	}, outByKey[1].Attributes)
+	}, outByKey[1].Value)
 	assert.Equal(t, "p4", outByKey[2].Key)
-	assert.Equal(t, Attributes{
+	assert.Equal(t, Doc{
 		"entry-pt":       "NY",
 		"arrival-time":   day2,
 		"departure-time": nil,
-	}, outByKey[2].Attributes)
+	}, outByKey[2].Value)
 
 	// -------------------- My extra tests --------------------
 	// elh: this was actually quite simple. the times are so early that they disregard so many edits. let's do a few
@@ -223,29 +225,29 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	require.Len(t, out, 4)
 	outByKey = sortDocumentsByKey(out)
 	assert.Equal(t, "p1", outByKey[0].Key) // this was not known in the original query. p1 info was recorded TT = day 4
-	assert.Equal(t, Attributes{
+	assert.Equal(t, Doc{
 		"entry-pt":       "NY",
 		"arrival-time":   day0,
 		"departure-time": nil,
-	}, outByKey[0].Attributes)
+	}, outByKey[0].Value)
 	assert.Equal(t, "p2", outByKey[1].Key)
-	assert.Equal(t, Attributes{
+	assert.Equal(t, Doc{
 		"entry-pt":       "SFO",
 		"arrival-time":   day0,
 		"departure-time": nil,
-	}, outByKey[1].Attributes)
+	}, outByKey[1].Value)
 	assert.Equal(t, "p3", outByKey[2].Key)
-	assert.Equal(t, Attributes{
+	assert.Equal(t, Doc{
 		"entry-pt":       "LA",
 		"arrival-time":   day0,
 		"departure-time": nil,
-	}, outByKey[2].Attributes)
+	}, outByKey[2].Value)
 	assert.Equal(t, "p4", outByKey[3].Key)
-	assert.Equal(t, Attributes{
+	assert.Equal(t, Doc{
 		"entry-pt":       "NY",
 		"arrival-time":   day2,
 		"departure-time": nil,
-	}, outByKey[3].Attributes)
+	}, outByKey[3].Value)
 
 	// state of db at now (VT = day 12, TT = day 12)
 	out, err = db.List()
@@ -253,47 +255,47 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	require.Len(t, out, 7)
 	outByKey = sortDocumentsByKey(out)
 	assert.Equal(t, "p1", outByKey[0].Key)
-	assert.Equal(t, Attributes{
+	assert.Equal(t, Doc{
 		"entry-pt":       "LA",
 		"arrival-time":   day4,
 		"departure-time": nil,
-	}, outByKey[0].Attributes)
+	}, outByKey[0].Value)
 	assert.Equal(t, "p2", outByKey[1].Key)
-	assert.Equal(t, Attributes{
+	assert.Equal(t, Doc{
 		"entry-pt":       "SFO",
 		"arrival-time":   day0,
 		"departure-time": day5,
-	}, outByKey[1].Attributes)
+	}, outByKey[1].Value)
 	assert.Equal(t, "p3", outByKey[2].Key)
-	assert.Equal(t, Attributes{
+	assert.Equal(t, Doc{
 		"entry-pt":       "SFO",
 		"arrival-time":   day8,
 		"departure-time": day8,
-	}, outByKey[2].Attributes)
+	}, outByKey[2].Value)
 	assert.Equal(t, "p4", outByKey[3].Key)
-	assert.Equal(t, Attributes{
+	assert.Equal(t, Doc{
 		"entry-pt":       "LA",
 		"arrival-time":   day8,
 		"departure-time": nil,
-	}, outByKey[3].Attributes)
+	}, outByKey[3].Value)
 	assert.Equal(t, "p5", outByKey[4].Key)
-	assert.Equal(t, Attributes{
+	assert.Equal(t, Doc{
 		"entry-pt":       "LA",
 		"arrival-time":   day10,
 		"departure-time": nil,
-	}, outByKey[4].Attributes)
+	}, outByKey[4].Value)
 	assert.Equal(t, "p6", outByKey[5].Key)
-	assert.Equal(t, Attributes{
+	assert.Equal(t, Doc{
 		"entry-pt":       "NY",
 		"arrival-time":   day12,
 		"departure-time": nil,
-	}, outByKey[5].Attributes)
+	}, outByKey[5].Value)
 	assert.Equal(t, "p7", outByKey[6].Key)
-	assert.Equal(t, Attributes{
+	assert.Equal(t, Doc{
 		"entry-pt":       "NY",
 		"arrival-time":   day11,
 		"departure-time": nil,
-	}, outByKey[6].Attributes)
+	}, outByKey[6].Value)
 }
 
 // Robinhood Eng blog > Tracking Temporal Data at Robinhood
@@ -303,17 +305,19 @@ func TestRobinhoodExample(t *testing.T) {
 	db, err := memory.NewDB()
 	require.Nil(t, err)
 
+	type Balance map[string]interface{}
+
 	// Say you deposit $100 in your account on 3/14.
 	mar14 := mustParseTime(shortForm, "2021-03-14")
 	db.SetNow(mar14)
-	require.Nil(t, db.Set("user-1", Attributes{
+	require.Nil(t, db.Set("user-1", Balance{
 		"cash-balance": 100,
 		"description":  "Deposit", // description of last event??
 	}))
 	// On 3/20, you purchase 1 share of ABC stock at $25.
 	mar20 := mustParseTime(shortForm, "2021-03-20")
 	db.SetNow(mar20)
-	require.Nil(t, db.Set("user-1", Attributes{
+	require.Nil(t, db.Set("user-1", Balance{
 		"cash-balance": 75,
 		"description":  "Stock Purchase",
 	}))
@@ -321,7 +325,7 @@ func TestRobinhoodExample(t *testing.T) {
 	// actually $10.
 	mar21 := mustParseTime(shortForm, "2021-03-21")
 	db.SetNow(mar21)
-	require.Nil(t, db.Set("user-1", Attributes{
+	require.Nil(t, db.Set("user-1", Balance{
 		"cash-balance": 90,
 		"description":  "Price Improvement",
 	},
@@ -331,7 +335,7 @@ func TestRobinhoodExample(t *testing.T) {
 	findBalance := func(opts ...ReadOpt) interface{} {
 		ret, err := db.Get("user-1", opts...)
 		require.Nil(t, err)
-		return ret.Attributes["cash-balance"]
+		return ret.Value.(Balance)["cash-balance"]
 	}
 	expectErrGetBalance := func(opts ...ReadOpt) {
 		_, err := db.Get("user-1", opts...)

--- a/memory/db_examples_test.go
+++ b/memory/db_examples_test.go
@@ -195,7 +195,7 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	out, err := db.List(AsOfValidTime(day2), AsOfTransactionTime(day3))
 	require.Nil(t, err)
 	require.Len(t, out, 3)
-	outByKey := sortValuesByKey(out)
+	outByKey := sortKVsByKey(out)
 	assert.Equal(t, "p2", outByKey[0].Key)
 	assert.Equal(t, Doc{
 		"entry-pt":       "SFO",
@@ -223,7 +223,7 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	out, err = db.List(AsOfValidTime(day2))
 	require.Nil(t, err)
 	require.Len(t, out, 4)
-	outByKey = sortValuesByKey(out)
+	outByKey = sortKVsByKey(out)
 	assert.Equal(t, "p1", outByKey[0].Key) // this was not known in the original query. p1 info was recorded TT = day 4
 	assert.Equal(t, Doc{
 		"entry-pt":       "NY",
@@ -253,7 +253,7 @@ func TestTXDBCrimeInvestigationExample(t *testing.T) {
 	out, err = db.List()
 	require.Nil(t, err)
 	require.Len(t, out, 7)
-	outByKey = sortValuesByKey(out)
+	outByKey = sortKVsByKey(out)
 	assert.Equal(t, "p1", outByKey[0].Key)
 	assert.Equal(t, Doc{
 		"entry-pt":       "LA",

--- a/memory/db_test.go
+++ b/memory/db_test.go
@@ -48,7 +48,7 @@ func TestConstructor(t *testing.T) {
 	type fixtures struct {
 		name string
 		// make sure structs isolated between tests while doing in-mem mutations
-		vValues func() []*VersionedValue
+		vKVs func() []*VersionedKV
 	}
 
 	type testCase struct {
@@ -62,8 +62,8 @@ func TestConstructor(t *testing.T) {
 	}{
 		{
 			fixtures: fixtures{
-				name:    "empty db",
-				vValues: func() []*VersionedValue { return nil },
+				name: "empty db",
+				vKVs: func() []*VersionedKV { return nil },
 			},
 			testCases: []testCase{
 				{
@@ -74,8 +74,8 @@ func TestConstructor(t *testing.T) {
 		{
 			fixtures: fixtures{
 				name: "overlapping transaction time",
-				vValues: func() []*VersionedValue {
-					return []*VersionedValue{
+				vKVs: func() []*VersionedKV {
+					return []*VersionedKV{
 						{
 							Key:            "A",
 							TxTimeStart:    t1,
@@ -104,8 +104,8 @@ func TestConstructor(t *testing.T) {
 		{
 			fixtures: fixtures{
 				name: "overlapping valid time",
-				vValues: func() []*VersionedValue {
-					return []*VersionedValue{
+				vKVs: func() []*VersionedKV {
+					return []*VersionedKV{
 						{
 							Key:            "A",
 							TxTimeStart:    t1,
@@ -134,8 +134,8 @@ func TestConstructor(t *testing.T) {
 		{
 			fixtures: fixtures{
 				name: "overlapping transaction time and valid time",
-				vValues: func() []*VersionedValue {
-					return []*VersionedValue{
+				vKVs: func() []*VersionedKV {
+					return []*VersionedKV{
 						{
 							Key:            "A",
 							TxTimeStart:    t1,
@@ -168,7 +168,7 @@ func TestConstructor(t *testing.T) {
 		for _, tC := range s.testCases {
 			tC := tC
 			t.Run(fmt.Sprintf("%v: %v", s.fixtures.name, tC.desc), func(t *testing.T) {
-				_, err := memory.NewDB(s.fixtures.vValues()...)
+				_, err := memory.NewDB(s.fixtures.vKVs()...)
 				if tC.expectErr {
 					require.NotNil(t, err)
 					return
@@ -183,14 +183,14 @@ func TestGet(t *testing.T) {
 	type fixtures struct {
 		name string
 		// make sure structs isolated between tests while doing in-mem mutations
-		vValues func() []*VersionedValue
+		vKVs func() []*VersionedKV
 	}
 
 	// 1 initial set
 	valuesSingleSet := fixtures{
 		name: "single set, no end",
-		vValues: func() []*VersionedValue {
-			return []*VersionedValue{
+		vKVs: func() []*VersionedKV {
+			return []*VersionedKV{
 				{
 					Key:            "A",
 					TxTimeStart:    t1,
@@ -205,8 +205,8 @@ func TestGet(t *testing.T) {
 	// 1 initial set with a valid time end
 	valuesSingleSetWithEnd := fixtures{
 		name: "single set, with end",
-		vValues: func() []*VersionedValue {
-			return []*VersionedValue{
+		vKVs: func() []*VersionedKV {
+			return []*VersionedKV{
 				{
 					Key:            "A",
 					TxTimeStart:    t1,
@@ -222,8 +222,8 @@ func TestGet(t *testing.T) {
 	// // this sets a TxTimeEnd for the initial record and creates 2 new ones
 	valuesUpdated := fixtures{
 		name: "initial set, and then set with later valid time",
-		vValues: func() []*VersionedValue {
-			return []*VersionedValue{
+		vKVs: func() []*VersionedKV {
+			return []*VersionedKV{
 				{
 					Key:            "A",
 					TxTimeStart:    t1,
@@ -253,8 +253,8 @@ func TestGet(t *testing.T) {
 	}
 	valuesDeleted := fixtures{
 		name: "initial set, and then deletion with later valid time",
-		vValues: func() []*VersionedValue {
-			return []*VersionedValue{
+		vKVs: func() []*VersionedKV {
+			return []*VersionedKV{
 				{
 					Key:            "A",
 					TxTimeStart:    t1,
@@ -290,8 +290,8 @@ func TestGet(t *testing.T) {
 	}{
 		{
 			fixtures: fixtures{
-				name:    "empty db",
-				vValues: func() []*VersionedValue { return nil },
+				name: "empty db",
+				vKVs: func() []*VersionedKV { return nil },
 			},
 			testCases: []testCase{
 				{
@@ -438,7 +438,7 @@ func TestGet(t *testing.T) {
 		for _, tC := range s.testCases {
 			tC := tC
 			t.Run(fmt.Sprintf("%v: %v", s.fixtures.name, tC.desc), func(t *testing.T) {
-				db, err := memory.NewDB(s.fixtures.vValues()...)
+				db, err := memory.NewDB(s.fixtures.vKVs()...)
 				require.Nil(t, err)
 				ret, err := db.Get(tC.key, tC.readOpts...)
 				if tC.expectErrNotFound {
@@ -460,10 +460,10 @@ func TestList(t *testing.T) {
 	type fixtures struct {
 		name string
 		// make sure structs isolated between tests while doing in-mem mutations
-		vValues func() []*VersionedValue
+		vKVs func() []*VersionedKV
 	}
 
-	aValue := &VersionedValue{
+	aValue := &VersionedKV{
 		Key:            "A",
 		TxTimeStart:    t1,
 		TxTimeEnd:      nil,
@@ -473,13 +473,13 @@ func TestList(t *testing.T) {
 	}
 	aFixtures := fixtures{
 		name: "A values",
-		vValues: func() []*VersionedValue {
-			return []*VersionedValue{
+		vKVs: func() []*VersionedKV {
+			return []*VersionedKV{
 				aValue,
 			}
 		},
 	}
-	bValue := &VersionedValue{
+	bValue := &VersionedKV{
 		Key:            "B",
 		TxTimeStart:    t1,
 		TxTimeEnd:      &t3,
@@ -487,7 +487,7 @@ func TestList(t *testing.T) {
 		ValidTimeEnd:   nil,
 		Value:          "Old",
 	}
-	bValueUpdate1 := &VersionedValue{
+	bValueUpdate1 := &VersionedKV{
 		Key:            "B",
 		TxTimeStart:    t3,
 		TxTimeEnd:      nil,
@@ -495,7 +495,7 @@ func TestList(t *testing.T) {
 		ValidTimeEnd:   &t3,
 		Value:          "Old",
 	}
-	bValueUpdate2 := &VersionedValue{
+	bValueUpdate2 := &VersionedKV{
 		Key:            "B",
 		TxTimeStart:    t3,
 		TxTimeEnd:      nil,
@@ -505,8 +505,8 @@ func TestList(t *testing.T) {
 	}
 	bFixtures := fixtures{
 		name: "A, B values",
-		vValues: func() []*VersionedValue {
-			return []*VersionedValue{
+		vKVs: func() []*VersionedKV {
+			return []*VersionedKV{
 				aValue,
 				bValue,
 				bValueUpdate1,
@@ -519,7 +519,7 @@ func TestList(t *testing.T) {
 		desc         string
 		readOpts     []ReadOpt
 		expectErr    bool
-		expectValues []*VersionedValue
+		expectValues []*VersionedKV
 	}
 
 	testCaseSets := []struct {
@@ -528,8 +528,8 @@ func TestList(t *testing.T) {
 	}{
 		{
 			fixtures: fixtures{
-				name:    "empty db",
-				vValues: func() []*VersionedValue { return nil },
+				name: "empty db",
+				vKVs: func() []*VersionedKV { return nil },
 			},
 			testCases: []testCase{
 				{
@@ -543,7 +543,7 @@ func TestList(t *testing.T) {
 			testCases: []testCase{
 				{
 					desc:         "found - default as of times",
-					expectValues: []*VersionedValue{aValue},
+					expectValues: []*VersionedKV{aValue},
 				},
 			},
 		},
@@ -552,7 +552,7 @@ func TestList(t *testing.T) {
 			testCases: []testCase{
 				{
 					desc:         "found - default as of times",
-					expectValues: []*VersionedValue{aValue, bValueUpdate2},
+					expectValues: []*VersionedKV{aValue, bValueUpdate2},
 				},
 				{
 					desc:         "not found - as of transaction time",
@@ -562,7 +562,7 @@ func TestList(t *testing.T) {
 				{
 					desc:         "found - as of valid time",
 					readOpts:     []ReadOpt{AsOfValidTime(t2)},
-					expectValues: []*VersionedValue{aValue, bValueUpdate1},
+					expectValues: []*VersionedKV{aValue, bValueUpdate1},
 				},
 			},
 		},
@@ -572,7 +572,7 @@ func TestList(t *testing.T) {
 		for _, tC := range s.testCases {
 			tC := tC
 			t.Run(fmt.Sprintf("%v: %v", s.fixtures.name, tC.desc), func(t *testing.T) {
-				db, err := memory.NewDB(s.fixtures.vValues()...)
+				db, err := memory.NewDB(s.fixtures.vKVs()...)
 				require.Nil(t, err)
 				ret, err := db.List(tC.readOpts...)
 				if tC.expectErr {
@@ -585,14 +585,14 @@ func TestList(t *testing.T) {
 				if len(tC.expectValues) == 0 {
 					return
 				}
-				assert.Equal(t, sortValuesByKey(tC.expectValues), sortValuesByKey(ret))
+				assert.Equal(t, sortKVsByKey(tC.expectValues), sortKVsByKey(ret))
 			})
 		}
 	}
 }
 
-func sortValuesByKey(ds []*VersionedValue) []*VersionedValue {
-	out := make([]*VersionedValue, len(ds))
+func sortKVsByKey(ds []*VersionedKV) []*VersionedKV {
+	out := make([]*VersionedKV, len(ds))
 	copy(out, ds)
 	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
 	return out
@@ -602,14 +602,14 @@ func TestSet(t *testing.T) {
 	type fixtures struct {
 		name string
 		// make sure structs isolated between tests while doing in-mem mutations
-		vValues func() []*VersionedValue
+		vKVs func() []*VersionedKV
 	}
 
 	// verify writes by checking result of find as of configured valid time and tx time
 	type findCheck struct {
 		readOpts          []ReadOpt
 		expectErrNotFound bool
-		expectValue       *VersionedValue
+		expectValue       *VersionedKV
 	}
 
 	type testCase struct {
@@ -629,8 +629,8 @@ func TestSet(t *testing.T) {
 	}{
 		{
 			fixtures: fixtures{
-				name:    "empty db",
-				vValues: func() []*VersionedValue { return nil },
+				name: "empty db",
+				vKVs: func() []*VersionedKV { return nil },
 			},
 			testCases: []testCase{
 				{
@@ -640,7 +640,7 @@ func TestSet(t *testing.T) {
 					value: "Old",
 					findChecks: []findCheck{
 						{
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      nil,
@@ -659,7 +659,7 @@ func TestSet(t *testing.T) {
 					writeOpts: []WriteOpt{WithValidTime(t0)},
 					findChecks: []findCheck{
 						{
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      nil,
@@ -678,7 +678,7 @@ func TestSet(t *testing.T) {
 					writeOpts: []WriteOpt{WithEndValidTime(t2)},
 					findChecks: []findCheck{
 						{
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      nil,
@@ -697,7 +697,7 @@ func TestSet(t *testing.T) {
 					writeOpts: []WriteOpt{WithValidTime(t0), WithEndValidTime(t3)},
 					findChecks: []findCheck{
 						{
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      nil,
@@ -715,7 +715,7 @@ func TestSet(t *testing.T) {
 					value: nil,
 					findChecks: []findCheck{
 						{
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      nil,
@@ -762,8 +762,8 @@ func TestSet(t *testing.T) {
 		{
 			fixtures: fixtures{
 				name: "existing entry - no valid end",
-				vValues: func() []*VersionedValue {
-					return []*VersionedValue{
+				vKVs: func() []*VersionedKV {
+					return []*VersionedKV{
 						{
 							Key:            "A",
 							TxTimeStart:    t1,
@@ -783,7 +783,7 @@ func TestSet(t *testing.T) {
 					value: "New",
 					findChecks: []findCheck{
 						{
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t3,
 								TxTimeEnd:      nil,
@@ -795,7 +795,7 @@ func TestSet(t *testing.T) {
 						// before update in valid time
 						{
 							readOpts: []ReadOpt{AsOfValidTime(t2)},
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t3,
 								TxTimeEnd:      nil,
@@ -807,7 +807,7 @@ func TestSet(t *testing.T) {
 						// before update in transaction time
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t2)},
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      &t3,
@@ -827,7 +827,7 @@ func TestSet(t *testing.T) {
 					findChecks: []findCheck{
 						// query as of now for valid time and transaction time. change not visible
 						{
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
@@ -839,7 +839,7 @@ func TestSet(t *testing.T) {
 						// query as of now for transaction time, before update for valid time. change not visible
 						{
 							readOpts: []ReadOpt{AsOfValidTime(t1)},
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
@@ -851,7 +851,7 @@ func TestSet(t *testing.T) {
 						// query as of now for valid time, before update for transaction time. change not visible
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t2)},
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      &t4,
@@ -863,7 +863,7 @@ func TestSet(t *testing.T) {
 						// query as of valid time in range, transaction time after update. change visible
 						{
 							readOpts: []ReadOpt{AsOfValidTime(t2), AsOfTransactionTime(t5)},
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
@@ -883,7 +883,7 @@ func TestSet(t *testing.T) {
 					findChecks: []findCheck{
 						// query as of now for valid time and transaction time. change visible
 						{
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
@@ -895,7 +895,7 @@ func TestSet(t *testing.T) {
 						// query as of now for valid time, before update for transaction time. change not visible
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t2)},
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      &t4,
@@ -911,8 +911,8 @@ func TestSet(t *testing.T) {
 		{
 			fixtures: fixtures{
 				name: "existing entries. multiple valid time ranges active",
-				vValues: func() []*VersionedValue {
-					return []*VersionedValue{
+				vKVs: func() []*VersionedKV {
+					return []*VersionedKV{
 						{
 							Key:            "A",
 							TxTimeStart:    t1,
@@ -951,7 +951,7 @@ func TestSet(t *testing.T) {
 						// TT = t5, VT = t4. after update transaction, not in valid range. too high
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t5)},
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
@@ -963,7 +963,7 @@ func TestSet(t *testing.T) {
 						// TT = t5, VT = t1. after update transaction, not in valid range. too low
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t5), AsOfValidTime(t1)},
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
@@ -975,7 +975,7 @@ func TestSet(t *testing.T) {
 						// TT = t5, VT = t3. after update transaction, in valid range
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t5), AsOfValidTime(t3)},
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
@@ -987,7 +987,7 @@ func TestSet(t *testing.T) {
 						// TT = t3, VT = t2 before update transaction, in the fixture original range
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t3), AsOfValidTime(t2)},
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t3,
 								TxTimeEnd:      &t4,
@@ -999,7 +999,7 @@ func TestSet(t *testing.T) {
 						// TT = t3, VT = t4. before update transaction, in the fixture updated range
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t3), AsOfValidTime(t4)},
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t3,
 								TxTimeEnd:      &t4,
@@ -1011,7 +1011,7 @@ func TestSet(t *testing.T) {
 						// TT = t2, VT = t2. before 1st fixture update transaction
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t2), AsOfValidTime(t2)},
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      &t3,
@@ -1030,7 +1030,7 @@ func TestSet(t *testing.T) {
 		for _, tC := range s.testCases {
 			tC := tC
 			t.Run(fmt.Sprintf("%v: %v", s.fixtures.name, tC.desc), func(t *testing.T) {
-				db, err := memory.NewDB(s.fixtures.vValues()...)
+				db, err := memory.NewDB(s.fixtures.vKVs()...)
 				require.Nil(t, err)
 				if tC.now != nil {
 					db.SetNow(*tC.now)
@@ -1060,14 +1060,14 @@ func TestDelete(t *testing.T) {
 	type fixtures struct {
 		name string
 		// make sure structs isolated between tests while doing in-mem mutations
-		vValues func() []*VersionedValue
+		vKVs func() []*VersionedKV
 	}
 
 	// verify writes by checking result of find as of configured valid time and tx time
 	type findCheck struct {
 		readOpts          []ReadOpt
 		expectErrNotFound bool
-		expectValue       *VersionedValue
+		expectValue       *VersionedKV
 	}
 
 	type testCase struct {
@@ -1086,8 +1086,8 @@ func TestDelete(t *testing.T) {
 	}{
 		{
 			fixtures: fixtures{
-				name:    "empty db",
-				vValues: func() []*VersionedValue { return nil },
+				name: "empty db",
+				vKVs: func() []*VersionedKV { return nil },
 			},
 			testCases: []testCase{
 				{
@@ -1105,8 +1105,8 @@ func TestDelete(t *testing.T) {
 		{
 			fixtures: fixtures{
 				name: "existing entry - no valid end",
-				vValues: func() []*VersionedValue {
-					return []*VersionedValue{
+				vKVs: func() []*VersionedKV {
+					return []*VersionedKV{
 						{
 							Key:            "A",
 							TxTimeStart:    t1,
@@ -1151,7 +1151,7 @@ func TestDelete(t *testing.T) {
 						// before update in valid time
 						{
 							readOpts: []ReadOpt{AsOfValidTime(t2)},
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t3,
 								TxTimeEnd:      nil,
@@ -1163,7 +1163,7 @@ func TestDelete(t *testing.T) {
 						// before update in transaction time
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t2)},
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      &t3,
@@ -1182,7 +1182,7 @@ func TestDelete(t *testing.T) {
 					findChecks: []findCheck{
 						// query as of now for valid time and transaction time. change not visible
 						{
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
@@ -1194,7 +1194,7 @@ func TestDelete(t *testing.T) {
 						// query as of now for transaction time, before update for valid time. change not visible
 						{
 							readOpts: []ReadOpt{AsOfValidTime(t1)},
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
@@ -1206,7 +1206,7 @@ func TestDelete(t *testing.T) {
 						// query as of now for valid time, before update for transaction time. change not visible
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t2)},
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      &t4,
@@ -1235,7 +1235,7 @@ func TestDelete(t *testing.T) {
 						// query as of now for valid time, before update for transaction time. change not visible
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t2)},
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      &t4,
@@ -1251,8 +1251,8 @@ func TestDelete(t *testing.T) {
 		{
 			fixtures: fixtures{
 				name: "existing entries. multiple valid time ranges active",
-				vValues: func() []*VersionedValue {
-					return []*VersionedValue{
+				vKVs: func() []*VersionedKV {
+					return []*VersionedKV{
 						{
 							Key:            "A",
 							TxTimeStart:    t1,
@@ -1290,7 +1290,7 @@ func TestDelete(t *testing.T) {
 						// TT = t5, VT = t4. after update transaction, not in valid range. too high
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t5)},
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
@@ -1302,7 +1302,7 @@ func TestDelete(t *testing.T) {
 						// TT = t5, VT = t1. after update transaction, not in valid range. too low
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t5), AsOfValidTime(t1)},
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
@@ -1319,7 +1319,7 @@ func TestDelete(t *testing.T) {
 						// TT = t3, VT = t2 before update transaction, in the fixture original range
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t3), AsOfValidTime(t2)},
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t3,
 								TxTimeEnd:      &t4,
@@ -1331,7 +1331,7 @@ func TestDelete(t *testing.T) {
 						// TT = t3, VT = t4. before update transaction, in the fixture updated range
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t3), AsOfValidTime(t4)},
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t3,
 								TxTimeEnd:      &t4,
@@ -1343,7 +1343,7 @@ func TestDelete(t *testing.T) {
 						// TT = t2, VT = t2. before 1st fixture update transaction
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t2), AsOfValidTime(t2)},
-							expectValue: &VersionedValue{
+							expectValue: &VersionedKV{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      &t3,
@@ -1362,7 +1362,7 @@ func TestDelete(t *testing.T) {
 		for _, tC := range s.testCases {
 			tC := tC
 			t.Run(fmt.Sprintf("%v: %v", s.fixtures.name, tC.desc), func(t *testing.T) {
-				db, err := memory.NewDB(s.fixtures.vValues()...)
+				db, err := memory.NewDB(s.fixtures.vKVs()...)
 				require.Nil(t, err)
 				if tC.now != nil {
 					db.SetNow(*tC.now)
@@ -1392,14 +1392,14 @@ func TestHistory(t *testing.T) {
 	type fixtures struct {
 		name string
 		// make sure structs isolated between tests while doing in-mem mutations
-		vValues func() []*VersionedValue
+		vKVs func() []*VersionedKV
 	}
 
 	// 1 initial set
 	valuesSingleSet := fixtures{
 		name: "single set, no end",
-		vValues: func() []*VersionedValue {
-			return []*VersionedValue{
+		vKVs: func() []*VersionedKV {
+			return []*VersionedKV{
 				{
 					Key:            "A",
 					TxTimeStart:    t1,
@@ -1414,8 +1414,8 @@ func TestHistory(t *testing.T) {
 	// 1 initial set with a valid time end
 	valuesSingleSetWithEnd := fixtures{
 		name: "single set, with end",
-		vValues: func() []*VersionedValue {
-			return []*VersionedValue{
+		vKVs: func() []*VersionedKV {
+			return []*VersionedKV{
 				{
 					Key:            "A",
 					TxTimeStart:    t1,
@@ -1431,8 +1431,8 @@ func TestHistory(t *testing.T) {
 	// // this sets a TxTimeEnd for the initial record and creates 2 new ones
 	valuesUpdated := fixtures{
 		name: "initial set, and then set with later valid time",
-		vValues: func() []*VersionedValue {
-			return []*VersionedValue{
+		vKVs: func() []*VersionedKV {
+			return []*VersionedKV{
 				{
 					Key:            "A",
 					TxTimeStart:    t1,
@@ -1462,8 +1462,8 @@ func TestHistory(t *testing.T) {
 	}
 	valuesDeleted := fixtures{
 		name: "initial set, and then deletion with later valid time",
-		vValues: func() []*VersionedValue {
-			return []*VersionedValue{
+		vKVs: func() []*VersionedKV {
+			return []*VersionedKV{
 				{
 					Key:            "A",
 					TxTimeStart:    t1,
@@ -1489,7 +1489,7 @@ func TestHistory(t *testing.T) {
 		key               string
 		expectErrNotFound bool
 		expectErr         bool // this is exclusive of ErrNotFound. this is for unexepcted errors
-		expectValues      []*VersionedValue
+		expectValues      []*VersionedKV
 	}
 
 	testCaseSets := []struct {
@@ -1498,8 +1498,8 @@ func TestHistory(t *testing.T) {
 	}{
 		{
 			fixtures: fixtures{
-				name:    "empty db",
-				vValues: func() []*VersionedValue { return nil },
+				name: "empty db",
+				vKVs: func() []*VersionedKV { return nil },
 			},
 			testCases: []testCase{
 				{
@@ -1515,7 +1515,7 @@ func TestHistory(t *testing.T) {
 				{
 					desc: "basic - return 1 version",
 					key:  "A",
-					expectValues: []*VersionedValue{
+					expectValues: []*VersionedKV{
 						{
 							Key:            "A",
 							TxTimeStart:    t1,
@@ -1534,7 +1534,7 @@ func TestHistory(t *testing.T) {
 				{
 					desc: "basic - return 1 version",
 					key:  "A",
-					expectValues: []*VersionedValue{
+					expectValues: []*VersionedKV{
 						{
 							Key:            "A",
 							TxTimeStart:    t1,
@@ -1553,7 +1553,7 @@ func TestHistory(t *testing.T) {
 				{
 					desc: "return versions by descending end transaction time, descending end valid time",
 					key:  "A",
-					expectValues: []*VersionedValue{
+					expectValues: []*VersionedKV{
 						{
 							Key:            "A",
 							TxTimeStart:    t3,
@@ -1588,7 +1588,7 @@ func TestHistory(t *testing.T) {
 				{
 					desc: "returns \"deleted\" versions",
 					key:  "A",
-					expectValues: []*VersionedValue{
+					expectValues: []*VersionedKV{
 						{
 							Key:            "A",
 							TxTimeStart:    t3,
@@ -1612,8 +1612,8 @@ func TestHistory(t *testing.T) {
 		{
 			fixtures: fixtures{
 				name: "version has later transaction time start, but earlier transaction time end",
-				vValues: func() []*VersionedValue {
-					return []*VersionedValue{
+				vKVs: func() []*VersionedKV {
+					return []*VersionedKV{
 						{
 							Key:            "A",
 							TxTimeStart:    t2,
@@ -1637,7 +1637,7 @@ func TestHistory(t *testing.T) {
 				{
 					desc: "return versions by descending end transaction time, descending end valid time",
 					key:  "A",
-					expectValues: []*VersionedValue{
+					expectValues: []*VersionedKV{
 						{
 							Key:            "A",
 							TxTimeStart:    t1,
@@ -1661,8 +1661,8 @@ func TestHistory(t *testing.T) {
 		{
 			fixtures: fixtures{
 				name: "multiple versions have nil end transaction time",
-				vValues: func() []*VersionedValue {
-					return []*VersionedValue{
+				vKVs: func() []*VersionedKV {
+					return []*VersionedKV{
 						{
 							Key:            "A",
 							TxTimeStart:    t1,
@@ -1686,7 +1686,7 @@ func TestHistory(t *testing.T) {
 				{
 					desc: "return versions by descending end transaction time, descending end valid time",
 					key:  "A",
-					expectValues: []*VersionedValue{
+					expectValues: []*VersionedKV{
 						{
 							Key:            "A",
 							TxTimeStart:    t2,
@@ -1713,7 +1713,7 @@ func TestHistory(t *testing.T) {
 		for _, tC := range s.testCases {
 			tC := tC
 			t.Run(fmt.Sprintf("%v: %v", s.fixtures.name, tC.desc), func(t *testing.T) {
-				db, err := memory.NewDB(s.fixtures.vValues()...)
+				db, err := memory.NewDB(s.fixtures.vKVs()...)
 				require.Nil(t, err)
 				ret, err := db.History(tC.key)
 				if tC.expectErrNotFound {

--- a/memory/db_test.go
+++ b/memory/db_test.go
@@ -177,7 +177,7 @@ func TestConstructor(t *testing.T) {
 	}
 }
 
-func TestFind(t *testing.T) {
+func TestGet(t *testing.T) {
 	type fixtures struct {
 		name string
 		// make sure structs isolated between tests while doing in-mem mutations
@@ -187,7 +187,7 @@ func TestFind(t *testing.T) {
 	put1Attrs := Attributes{"score": 100}
 	put2Attrs := Attributes{"score": 200}
 	// 1 initial put
-	aDocsSinglePut := fixtures{
+	aDocsSingleSet := fixtures{
 		name: "single put, no end",
 		documents: func() []*Document {
 			return []*Document{
@@ -203,7 +203,7 @@ func TestFind(t *testing.T) {
 		},
 	}
 	// 1 initial put with a valid time end
-	aDocsSinglePutWithEnd := fixtures{
+	aDocsSingleSetWithEnd := fixtures{
 		name: "single put, with end",
 		documents: func() []*Document {
 			return []*Document{
@@ -302,7 +302,7 @@ func TestFind(t *testing.T) {
 			},
 		},
 		{
-			fixtures: aDocsSinglePut,
+			fixtures: aDocsSingleSet,
 			testCases: []testCase{
 				{
 					desc:             "found - default as of times",
@@ -348,7 +348,7 @@ func TestFind(t *testing.T) {
 			},
 		},
 		{
-			fixtures: aDocsSinglePutWithEnd,
+			fixtures: aDocsSingleSetWithEnd,
 			testCases: []testCase{
 				{
 					desc:             "found - as of valid and tx time T in range",
@@ -440,7 +440,7 @@ func TestFind(t *testing.T) {
 			t.Run(fmt.Sprintf("%v: %v", s.fixtures.name, tC.desc), func(t *testing.T) {
 				db, err := memory.NewDB(s.fixtures.documents()...)
 				require.Nil(t, err)
-				ret, err := db.Find(tC.id, tC.readOpts...)
+				ret, err := db.Get(tC.id, tC.readOpts...)
 				if tC.expectErrNotFound {
 					require.ErrorIs(t, err, ErrNotFound)
 					return
@@ -606,7 +606,7 @@ func sortDocumentsByID(ds []*Document) []*Document {
 	return out
 }
 
-func TestPut(t *testing.T) {
+func TestSet(t *testing.T) {
 	type fixtures struct {
 		name string
 		// make sure structs isolated between tests while doing in-mem mutations
@@ -1065,7 +1065,7 @@ func TestPut(t *testing.T) {
 				if tC.now != nil {
 					db.SetNow(*tC.now)
 				}
-				err = db.Put(tC.id, tC.attributes, tC.writeOpts...)
+				err = db.Set(tC.id, tC.attributes, tC.writeOpts...)
 				if tC.expectErr {
 					require.NotNil(t, err)
 					return
@@ -1073,7 +1073,7 @@ func TestPut(t *testing.T) {
 				require.Nil(t, err)
 
 				for _, findCheck := range tC.findChecks {
-					ret, err := db.Find(tC.id, findCheck.readOpts...)
+					ret, err := db.Get(tC.id, findCheck.readOpts...)
 					if findCheck.expectErrNotFound {
 						require.ErrorIs(t, err, ErrNotFound)
 						return
@@ -1429,7 +1429,7 @@ func TestDelete(t *testing.T) {
 				require.Nil(t, err)
 
 				for _, findCheck := range tC.findChecks {
-					ret, err := db.Find(tC.id, findCheck.readOpts...)
+					ret, err := db.Get(tC.id, findCheck.readOpts...)
 					if findCheck.expectErrNotFound {
 						require.ErrorIs(t, err, ErrNotFound)
 						return
@@ -1452,7 +1452,7 @@ func TestHistory(t *testing.T) {
 	put1Attrs := Attributes{"score": 100}
 	put2Attrs := Attributes{"score": 200}
 	// 1 initial put
-	aDocsSinglePut := fixtures{
+	aDocsSingleSet := fixtures{
 		name: "single put, no end",
 		documents: func() []*Document {
 			return []*Document{
@@ -1468,7 +1468,7 @@ func TestHistory(t *testing.T) {
 		},
 	}
 	// 1 initial put with a valid time end
-	aDocsSinglePutWithEnd := fixtures{
+	aDocsSingleSetWithEnd := fixtures{
 		name: "single put, with end",
 		documents: func() []*Document {
 			return []*Document{
@@ -1566,7 +1566,7 @@ func TestHistory(t *testing.T) {
 			},
 		},
 		{
-			fixtures: aDocsSinglePut,
+			fixtures: aDocsSingleSet,
 			testCases: []testCase{
 				{
 					desc: "basic - return 1 version",
@@ -1585,7 +1585,7 @@ func TestHistory(t *testing.T) {
 			},
 		},
 		{
-			fixtures: aDocsSinglePutWithEnd,
+			fixtures: aDocsSingleSetWithEnd,
 			testCases: []testCase{
 				{
 					desc: "basic - return 1 version",

--- a/memory/db_test.go
+++ b/memory/db_test.go
@@ -166,7 +166,7 @@ func TestConstructor(t *testing.T) {
 		for _, tC := range s.testCases {
 			tC := tC
 			t.Run(fmt.Sprintf("%v: %v", s.fixtures.name, tC.desc), func(t *testing.T) {
-				_, err := memory.NewDB(s.fixtures.documents())
+				_, err := memory.NewDB(s.fixtures.documents()...)
 				if tC.expectErr {
 					require.NotNil(t, err)
 					return
@@ -438,7 +438,7 @@ func TestFind(t *testing.T) {
 		for _, tC := range s.testCases {
 			tC := tC
 			t.Run(fmt.Sprintf("%v: %v", s.fixtures.name, tC.desc), func(t *testing.T) {
-				db, err := memory.NewDB(s.fixtures.documents())
+				db, err := memory.NewDB(s.fixtures.documents()...)
 				require.Nil(t, err)
 				ret, err := db.Find(tC.id, tC.readOpts...)
 				if tC.expectErrNotFound {
@@ -580,7 +580,7 @@ func TestList(t *testing.T) {
 		for _, tC := range s.testCases {
 			tC := tC
 			t.Run(fmt.Sprintf("%v: %v", s.fixtures.name, tC.desc), func(t *testing.T) {
-				db, err := memory.NewDB(s.fixtures.documents())
+				db, err := memory.NewDB(s.fixtures.documents()...)
 				require.Nil(t, err)
 				ret, err := db.List(tC.readOpts...)
 				if tC.expectErr {
@@ -1060,7 +1060,7 @@ func TestPut(t *testing.T) {
 		for _, tC := range s.testCases {
 			tC := tC
 			t.Run(fmt.Sprintf("%v: %v", s.fixtures.name, tC.desc), func(t *testing.T) {
-				db, err := memory.NewDB(s.fixtures.documents())
+				db, err := memory.NewDB(s.fixtures.documents()...)
 				require.Nil(t, err)
 				if tC.now != nil {
 					db.SetNow(*tC.now)
@@ -1416,7 +1416,7 @@ func TestDelete(t *testing.T) {
 		for _, tC := range s.testCases {
 			tC := tC
 			t.Run(fmt.Sprintf("%v: %v", s.fixtures.name, tC.desc), func(t *testing.T) {
-				db, err := memory.NewDB(s.fixtures.documents())
+				db, err := memory.NewDB(s.fixtures.documents()...)
 				require.Nil(t, err)
 				if tC.now != nil {
 					db.SetNow(*tC.now)
@@ -1769,7 +1769,7 @@ func TestHistory(t *testing.T) {
 		for _, tC := range s.testCases {
 			tC := tC
 			t.Run(fmt.Sprintf("%v: %v", s.fixtures.name, tC.desc), func(t *testing.T) {
-				db, err := memory.NewDB(s.fixtures.documents())
+				db, err := memory.NewDB(s.fixtures.documents()...)
 				require.Nil(t, err)
 				ret, err := db.History(tC.id)
 				if tC.expectErrNotFound {

--- a/memory/db_test.go
+++ b/memory/db_test.go
@@ -48,7 +48,7 @@ func TestConstructor(t *testing.T) {
 	type fixtures struct {
 		name string
 		// make sure structs isolated between tests while doing in-mem mutations
-		documents func() []*Document
+		vValues func() []*VersionedValue
 	}
 
 	type testCase struct {
@@ -62,8 +62,8 @@ func TestConstructor(t *testing.T) {
 	}{
 		{
 			fixtures: fixtures{
-				name:      "empty db",
-				documents: func() []*Document { return nil },
+				name:    "empty db",
+				vValues: func() []*VersionedValue { return nil },
 			},
 			testCases: []testCase{
 				{
@@ -74,8 +74,8 @@ func TestConstructor(t *testing.T) {
 		{
 			fixtures: fixtures{
 				name: "overlapping transaction time",
-				documents: func() []*Document {
-					return []*Document{
+				vValues: func() []*VersionedValue {
+					return []*VersionedValue{
 						{
 							Key:            "A",
 							TxTimeStart:    t1,
@@ -104,8 +104,8 @@ func TestConstructor(t *testing.T) {
 		{
 			fixtures: fixtures{
 				name: "overlapping valid time",
-				documents: func() []*Document {
-					return []*Document{
+				vValues: func() []*VersionedValue {
+					return []*VersionedValue{
 						{
 							Key:            "A",
 							TxTimeStart:    t1,
@@ -134,8 +134,8 @@ func TestConstructor(t *testing.T) {
 		{
 			fixtures: fixtures{
 				name: "overlapping transaction time and valid time",
-				documents: func() []*Document {
-					return []*Document{
+				vValues: func() []*VersionedValue {
+					return []*VersionedValue{
 						{
 							Key:            "A",
 							TxTimeStart:    t1,
@@ -168,7 +168,7 @@ func TestConstructor(t *testing.T) {
 		for _, tC := range s.testCases {
 			tC := tC
 			t.Run(fmt.Sprintf("%v: %v", s.fixtures.name, tC.desc), func(t *testing.T) {
-				_, err := memory.NewDB(s.fixtures.documents()...)
+				_, err := memory.NewDB(s.fixtures.vValues()...)
 				if tC.expectErr {
 					require.NotNil(t, err)
 					return
@@ -183,14 +183,14 @@ func TestGet(t *testing.T) {
 	type fixtures struct {
 		name string
 		// make sure structs isolated between tests while doing in-mem mutations
-		documents func() []*Document
+		vValues func() []*VersionedValue
 	}
 
 	// 1 initial set
-	aDocsSingleSet := fixtures{
+	valuesSingleSet := fixtures{
 		name: "single set, no end",
-		documents: func() []*Document {
-			return []*Document{
+		vValues: func() []*VersionedValue {
+			return []*VersionedValue{
 				{
 					Key:            "A",
 					TxTimeStart:    t1,
@@ -203,10 +203,10 @@ func TestGet(t *testing.T) {
 		},
 	}
 	// 1 initial set with a valid time end
-	aDocsSingleSetWithEnd := fixtures{
+	valuesSingleSetWithEnd := fixtures{
 		name: "single set, with end",
-		documents: func() []*Document {
-			return []*Document{
+		vValues: func() []*VersionedValue {
+			return []*VersionedValue{
 				{
 					Key:            "A",
 					TxTimeStart:    t1,
@@ -220,10 +220,10 @@ func TestGet(t *testing.T) {
 	}
 	// // 1 initial set and 1 set with later valid time updating score
 	// // this sets a TxTimeEnd for the initial record and creates 2 new ones
-	aDocsUpdated := fixtures{
+	valuesUpdated := fixtures{
 		name: "initial set, and then set with later valid time",
-		documents: func() []*Document {
-			return []*Document{
+		vValues: func() []*VersionedValue {
+			return []*VersionedValue{
 				{
 					Key:            "A",
 					TxTimeStart:    t1,
@@ -251,10 +251,10 @@ func TestGet(t *testing.T) {
 			}
 		},
 	}
-	aDocsDeleted := fixtures{
+	valuesDeleted := fixtures{
 		name: "initial set, and then deletion with later valid time",
-		documents: func() []*Document {
-			return []*Document{
+		vValues: func() []*VersionedValue {
+			return []*VersionedValue{
 				{
 					Key:            "A",
 					TxTimeStart:    t1,
@@ -290,8 +290,8 @@ func TestGet(t *testing.T) {
 	}{
 		{
 			fixtures: fixtures{
-				name:      "empty db",
-				documents: func() []*Document { return nil },
+				name:    "empty db",
+				vValues: func() []*VersionedValue { return nil },
 			},
 			testCases: []testCase{
 				{
@@ -302,7 +302,7 @@ func TestGet(t *testing.T) {
 			},
 		},
 		{
-			fixtures: aDocsSingleSet,
+			fixtures: valuesSingleSet,
 			testCases: []testCase{
 				{
 					desc:        "found - default as of times",
@@ -348,7 +348,7 @@ func TestGet(t *testing.T) {
 			},
 		},
 		{
-			fixtures: aDocsSingleSetWithEnd,
+			fixtures: valuesSingleSetWithEnd,
 			testCases: []testCase{
 				{
 					desc:        "found - as of valid and tx time T in range",
@@ -377,7 +377,7 @@ func TestGet(t *testing.T) {
 			},
 		},
 		{
-			fixtures: aDocsUpdated,
+			fixtures: valuesUpdated,
 			testCases: []testCase{
 				{
 					desc:        "found - default as of times",
@@ -405,7 +405,7 @@ func TestGet(t *testing.T) {
 			},
 		},
 		{
-			fixtures: aDocsDeleted,
+			fixtures: valuesDeleted,
 			testCases: []testCase{
 				{
 					desc:              "not found - default as of times",
@@ -438,7 +438,7 @@ func TestGet(t *testing.T) {
 		for _, tC := range s.testCases {
 			tC := tC
 			t.Run(fmt.Sprintf("%v: %v", s.fixtures.name, tC.desc), func(t *testing.T) {
-				db, err := memory.NewDB(s.fixtures.documents()...)
+				db, err := memory.NewDB(s.fixtures.vValues()...)
 				require.Nil(t, err)
 				ret, err := db.Get(tC.key, tC.readOpts...)
 				if tC.expectErrNotFound {
@@ -460,10 +460,10 @@ func TestList(t *testing.T) {
 	type fixtures struct {
 		name string
 		// make sure structs isolated between tests while doing in-mem mutations
-		documents func() []*Document
+		vValues func() []*VersionedValue
 	}
 
-	aDoc := &Document{
+	aValue := &VersionedValue{
 		Key:            "A",
 		TxTimeStart:    t1,
 		TxTimeEnd:      nil,
@@ -472,14 +472,14 @@ func TestList(t *testing.T) {
 		Value:          "Old",
 	}
 	aFixtures := fixtures{
-		name: "A document",
-		documents: func() []*Document {
-			return []*Document{
-				aDoc,
+		name: "A values",
+		vValues: func() []*VersionedValue {
+			return []*VersionedValue{
+				aValue,
 			}
 		},
 	}
-	bDoc := &Document{
+	bValue := &VersionedValue{
 		Key:            "B",
 		TxTimeStart:    t1,
 		TxTimeEnd:      &t3,
@@ -487,7 +487,7 @@ func TestList(t *testing.T) {
 		ValidTimeEnd:   nil,
 		Value:          "Old",
 	}
-	bDocUpdate1 := &Document{
+	bValueUpdate1 := &VersionedValue{
 		Key:            "B",
 		TxTimeStart:    t3,
 		TxTimeEnd:      nil,
@@ -495,7 +495,7 @@ func TestList(t *testing.T) {
 		ValidTimeEnd:   &t3,
 		Value:          "Old",
 	}
-	bDocUpdate2 := &Document{
+	bValueUpdate2 := &VersionedValue{
 		Key:            "B",
 		TxTimeStart:    t3,
 		TxTimeEnd:      nil,
@@ -504,22 +504,22 @@ func TestList(t *testing.T) {
 		Value:          "New",
 	}
 	bFixtures := fixtures{
-		name: "A, B documents",
-		documents: func() []*Document {
-			return []*Document{
-				aDoc,
-				bDoc,
-				bDocUpdate1,
-				bDocUpdate2,
+		name: "A, B values",
+		vValues: func() []*VersionedValue {
+			return []*VersionedValue{
+				aValue,
+				bValue,
+				bValueUpdate1,
+				bValueUpdate2,
 			}
 		},
 	}
 
 	type testCase struct {
-		desc            string
-		readOpts        []ReadOpt
-		expectErr       bool
-		expectDocuments []*Document
+		desc         string
+		readOpts     []ReadOpt
+		expectErr    bool
+		expectValues []*VersionedValue
 	}
 
 	testCaseSets := []struct {
@@ -528,13 +528,13 @@ func TestList(t *testing.T) {
 	}{
 		{
 			fixtures: fixtures{
-				name:      "empty db",
-				documents: func() []*Document { return nil },
+				name:    "empty db",
+				vValues: func() []*VersionedValue { return nil },
 			},
 			testCases: []testCase{
 				{
-					desc:            "not found",
-					expectDocuments: nil,
+					desc:         "not found",
+					expectValues: nil,
 				},
 			},
 		},
@@ -542,8 +542,8 @@ func TestList(t *testing.T) {
 			fixtures: aFixtures,
 			testCases: []testCase{
 				{
-					desc:            "found - default as of times",
-					expectDocuments: []*Document{aDoc},
+					desc:         "found - default as of times",
+					expectValues: []*VersionedValue{aValue},
 				},
 			},
 		},
@@ -551,18 +551,18 @@ func TestList(t *testing.T) {
 			fixtures: bFixtures,
 			testCases: []testCase{
 				{
-					desc:            "found - default as of times",
-					expectDocuments: []*Document{aDoc, bDocUpdate2},
+					desc:         "found - default as of times",
+					expectValues: []*VersionedValue{aValue, bValueUpdate2},
 				},
 				{
-					desc:            "not found - as of transaction time",
-					readOpts:        []ReadOpt{AsOfTransactionTime(t0)},
-					expectDocuments: nil,
+					desc:         "not found - as of transaction time",
+					readOpts:     []ReadOpt{AsOfTransactionTime(t0)},
+					expectValues: nil,
 				},
 				{
-					desc:            "found - as of valid time",
-					readOpts:        []ReadOpt{AsOfValidTime(t2)},
-					expectDocuments: []*Document{aDoc, bDocUpdate1},
+					desc:         "found - as of valid time",
+					readOpts:     []ReadOpt{AsOfValidTime(t2)},
+					expectValues: []*VersionedValue{aValue, bValueUpdate1},
 				},
 			},
 		},
@@ -572,7 +572,7 @@ func TestList(t *testing.T) {
 		for _, tC := range s.testCases {
 			tC := tC
 			t.Run(fmt.Sprintf("%v: %v", s.fixtures.name, tC.desc), func(t *testing.T) {
-				db, err := memory.NewDB(s.fixtures.documents()...)
+				db, err := memory.NewDB(s.fixtures.vValues()...)
 				require.Nil(t, err)
 				ret, err := db.List(tC.readOpts...)
 				if tC.expectErr {
@@ -581,18 +581,18 @@ func TestList(t *testing.T) {
 					return
 				}
 				require.Nil(t, err)
-				require.Len(t, ret, len(tC.expectDocuments))
-				if len(tC.expectDocuments) == 0 {
+				require.Len(t, ret, len(tC.expectValues))
+				if len(tC.expectValues) == 0 {
 					return
 				}
-				assert.Equal(t, sortDocumentsByKey(tC.expectDocuments), sortDocumentsByKey(ret))
+				assert.Equal(t, sortValuesByKey(tC.expectValues), sortValuesByKey(ret))
 			})
 		}
 	}
 }
 
-func sortDocumentsByKey(ds []*Document) []*Document {
-	out := make([]*Document, len(ds))
+func sortValuesByKey(ds []*VersionedValue) []*VersionedValue {
+	out := make([]*VersionedValue, len(ds))
 	copy(out, ds)
 	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
 	return out
@@ -602,14 +602,14 @@ func TestSet(t *testing.T) {
 	type fixtures struct {
 		name string
 		// make sure structs isolated between tests while doing in-mem mutations
-		documents func() []*Document
+		vValues func() []*VersionedValue
 	}
 
 	// verify writes by checking result of find as of configured valid time and tx time
 	type findCheck struct {
 		readOpts          []ReadOpt
 		expectErrNotFound bool
-		expectDocument    *Document
+		expectValue       *VersionedValue
 	}
 
 	type testCase struct {
@@ -629,8 +629,8 @@ func TestSet(t *testing.T) {
 	}{
 		{
 			fixtures: fixtures{
-				name:      "empty db",
-				documents: func() []*Document { return nil },
+				name:    "empty db",
+				vValues: func() []*VersionedValue { return nil },
 			},
 			testCases: []testCase{
 				{
@@ -640,7 +640,7 @@ func TestSet(t *testing.T) {
 					value: "Old",
 					findChecks: []findCheck{
 						{
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      nil,
@@ -659,7 +659,7 @@ func TestSet(t *testing.T) {
 					writeOpts: []WriteOpt{WithValidTime(t0)},
 					findChecks: []findCheck{
 						{
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      nil,
@@ -678,7 +678,7 @@ func TestSet(t *testing.T) {
 					writeOpts: []WriteOpt{WithEndValidTime(t2)},
 					findChecks: []findCheck{
 						{
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      nil,
@@ -697,7 +697,7 @@ func TestSet(t *testing.T) {
 					writeOpts: []WriteOpt{WithValidTime(t0), WithEndValidTime(t3)},
 					findChecks: []findCheck{
 						{
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      nil,
@@ -715,7 +715,7 @@ func TestSet(t *testing.T) {
 					value: nil,
 					findChecks: []findCheck{
 						{
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      nil,
@@ -762,8 +762,8 @@ func TestSet(t *testing.T) {
 		{
 			fixtures: fixtures{
 				name: "existing entry - no valid end",
-				documents: func() []*Document {
-					return []*Document{
+				vValues: func() []*VersionedValue {
+					return []*VersionedValue{
 						{
 							Key:            "A",
 							TxTimeStart:    t1,
@@ -783,7 +783,7 @@ func TestSet(t *testing.T) {
 					value: "New",
 					findChecks: []findCheck{
 						{
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t3,
 								TxTimeEnd:      nil,
@@ -795,7 +795,7 @@ func TestSet(t *testing.T) {
 						// before update in valid time
 						{
 							readOpts: []ReadOpt{AsOfValidTime(t2)},
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t3,
 								TxTimeEnd:      nil,
@@ -807,7 +807,7 @@ func TestSet(t *testing.T) {
 						// before update in transaction time
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t2)},
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      &t3,
@@ -827,7 +827,7 @@ func TestSet(t *testing.T) {
 					findChecks: []findCheck{
 						// query as of now for valid time and transaction time. change not visible
 						{
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
@@ -839,7 +839,7 @@ func TestSet(t *testing.T) {
 						// query as of now for transaction time, before update for valid time. change not visible
 						{
 							readOpts: []ReadOpt{AsOfValidTime(t1)},
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
@@ -851,7 +851,7 @@ func TestSet(t *testing.T) {
 						// query as of now for valid time, before update for transaction time. change not visible
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t2)},
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      &t4,
@@ -863,7 +863,7 @@ func TestSet(t *testing.T) {
 						// query as of valid time in range, transaction time after update. change visible
 						{
 							readOpts: []ReadOpt{AsOfValidTime(t2), AsOfTransactionTime(t5)},
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
@@ -883,7 +883,7 @@ func TestSet(t *testing.T) {
 					findChecks: []findCheck{
 						// query as of now for valid time and transaction time. change visible
 						{
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
@@ -895,7 +895,7 @@ func TestSet(t *testing.T) {
 						// query as of now for valid time, before update for transaction time. change not visible
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t2)},
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      &t4,
@@ -911,8 +911,8 @@ func TestSet(t *testing.T) {
 		{
 			fixtures: fixtures{
 				name: "existing entries. multiple valid time ranges active",
-				documents: func() []*Document {
-					return []*Document{
+				vValues: func() []*VersionedValue {
+					return []*VersionedValue{
 						{
 							Key:            "A",
 							TxTimeStart:    t1,
@@ -951,7 +951,7 @@ func TestSet(t *testing.T) {
 						// TT = t5, VT = t4. after update transaction, not in valid range. too high
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t5)},
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
@@ -963,7 +963,7 @@ func TestSet(t *testing.T) {
 						// TT = t5, VT = t1. after update transaction, not in valid range. too low
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t5), AsOfValidTime(t1)},
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
@@ -975,7 +975,7 @@ func TestSet(t *testing.T) {
 						// TT = t5, VT = t3. after update transaction, in valid range
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t5), AsOfValidTime(t3)},
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
@@ -987,7 +987,7 @@ func TestSet(t *testing.T) {
 						// TT = t3, VT = t2 before update transaction, in the fixture original range
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t3), AsOfValidTime(t2)},
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t3,
 								TxTimeEnd:      &t4,
@@ -999,7 +999,7 @@ func TestSet(t *testing.T) {
 						// TT = t3, VT = t4. before update transaction, in the fixture updated range
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t3), AsOfValidTime(t4)},
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t3,
 								TxTimeEnd:      &t4,
@@ -1011,7 +1011,7 @@ func TestSet(t *testing.T) {
 						// TT = t2, VT = t2. before 1st fixture update transaction
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t2), AsOfValidTime(t2)},
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      &t3,
@@ -1030,7 +1030,7 @@ func TestSet(t *testing.T) {
 		for _, tC := range s.testCases {
 			tC := tC
 			t.Run(fmt.Sprintf("%v: %v", s.fixtures.name, tC.desc), func(t *testing.T) {
-				db, err := memory.NewDB(s.fixtures.documents()...)
+				db, err := memory.NewDB(s.fixtures.vValues()...)
 				require.Nil(t, err)
 				if tC.now != nil {
 					db.SetNow(*tC.now)
@@ -1049,7 +1049,7 @@ func TestSet(t *testing.T) {
 						return
 					}
 					require.Nil(t, err)
-					assert.Equal(t, findCheck.expectDocument, ret)
+					assert.Equal(t, findCheck.expectValue, ret)
 				}
 			})
 		}
@@ -1060,14 +1060,14 @@ func TestDelete(t *testing.T) {
 	type fixtures struct {
 		name string
 		// make sure structs isolated between tests while doing in-mem mutations
-		documents func() []*Document
+		vValues func() []*VersionedValue
 	}
 
 	// verify writes by checking result of find as of configured valid time and tx time
 	type findCheck struct {
 		readOpts          []ReadOpt
 		expectErrNotFound bool
-		expectDocument    *Document
+		expectValue       *VersionedValue
 	}
 
 	type testCase struct {
@@ -1086,8 +1086,8 @@ func TestDelete(t *testing.T) {
 	}{
 		{
 			fixtures: fixtures{
-				name:      "empty db",
-				documents: func() []*Document { return nil },
+				name:    "empty db",
+				vValues: func() []*VersionedValue { return nil },
 			},
 			testCases: []testCase{
 				{
@@ -1105,8 +1105,8 @@ func TestDelete(t *testing.T) {
 		{
 			fixtures: fixtures{
 				name: "existing entry - no valid end",
-				documents: func() []*Document {
-					return []*Document{
+				vValues: func() []*VersionedValue {
+					return []*VersionedValue{
 						{
 							Key:            "A",
 							TxTimeStart:    t1,
@@ -1151,7 +1151,7 @@ func TestDelete(t *testing.T) {
 						// before update in valid time
 						{
 							readOpts: []ReadOpt{AsOfValidTime(t2)},
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t3,
 								TxTimeEnd:      nil,
@@ -1163,7 +1163,7 @@ func TestDelete(t *testing.T) {
 						// before update in transaction time
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t2)},
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      &t3,
@@ -1182,7 +1182,7 @@ func TestDelete(t *testing.T) {
 					findChecks: []findCheck{
 						// query as of now for valid time and transaction time. change not visible
 						{
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
@@ -1194,7 +1194,7 @@ func TestDelete(t *testing.T) {
 						// query as of now for transaction time, before update for valid time. change not visible
 						{
 							readOpts: []ReadOpt{AsOfValidTime(t1)},
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
@@ -1206,7 +1206,7 @@ func TestDelete(t *testing.T) {
 						// query as of now for valid time, before update for transaction time. change not visible
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t2)},
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      &t4,
@@ -1235,7 +1235,7 @@ func TestDelete(t *testing.T) {
 						// query as of now for valid time, before update for transaction time. change not visible
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t2)},
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      &t4,
@@ -1251,8 +1251,8 @@ func TestDelete(t *testing.T) {
 		{
 			fixtures: fixtures{
 				name: "existing entries. multiple valid time ranges active",
-				documents: func() []*Document {
-					return []*Document{
+				vValues: func() []*VersionedValue {
+					return []*VersionedValue{
 						{
 							Key:            "A",
 							TxTimeStart:    t1,
@@ -1290,7 +1290,7 @@ func TestDelete(t *testing.T) {
 						// TT = t5, VT = t4. after update transaction, not in valid range. too high
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t5)},
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
@@ -1302,7 +1302,7 @@ func TestDelete(t *testing.T) {
 						// TT = t5, VT = t1. after update transaction, not in valid range. too low
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t5), AsOfValidTime(t1)},
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
@@ -1319,7 +1319,7 @@ func TestDelete(t *testing.T) {
 						// TT = t3, VT = t2 before update transaction, in the fixture original range
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t3), AsOfValidTime(t2)},
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t3,
 								TxTimeEnd:      &t4,
@@ -1331,7 +1331,7 @@ func TestDelete(t *testing.T) {
 						// TT = t3, VT = t4. before update transaction, in the fixture updated range
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t3), AsOfValidTime(t4)},
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t3,
 								TxTimeEnd:      &t4,
@@ -1343,7 +1343,7 @@ func TestDelete(t *testing.T) {
 						// TT = t2, VT = t2. before 1st fixture update transaction
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t2), AsOfValidTime(t2)},
-							expectDocument: &Document{
+							expectValue: &VersionedValue{
 								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      &t3,
@@ -1362,7 +1362,7 @@ func TestDelete(t *testing.T) {
 		for _, tC := range s.testCases {
 			tC := tC
 			t.Run(fmt.Sprintf("%v: %v", s.fixtures.name, tC.desc), func(t *testing.T) {
-				db, err := memory.NewDB(s.fixtures.documents()...)
+				db, err := memory.NewDB(s.fixtures.vValues()...)
 				require.Nil(t, err)
 				if tC.now != nil {
 					db.SetNow(*tC.now)
@@ -1381,7 +1381,7 @@ func TestDelete(t *testing.T) {
 						return
 					}
 					require.Nil(t, err)
-					assert.Equal(t, findCheck.expectDocument, ret)
+					assert.Equal(t, findCheck.expectValue, ret)
 				}
 			})
 		}
@@ -1392,14 +1392,14 @@ func TestHistory(t *testing.T) {
 	type fixtures struct {
 		name string
 		// make sure structs isolated between tests while doing in-mem mutations
-		documents func() []*Document
+		vValues func() []*VersionedValue
 	}
 
 	// 1 initial set
-	aDocsSingleSet := fixtures{
+	valuesSingleSet := fixtures{
 		name: "single set, no end",
-		documents: func() []*Document {
-			return []*Document{
+		vValues: func() []*VersionedValue {
+			return []*VersionedValue{
 				{
 					Key:            "A",
 					TxTimeStart:    t1,
@@ -1412,10 +1412,10 @@ func TestHistory(t *testing.T) {
 		},
 	}
 	// 1 initial set with a valid time end
-	aDocsSingleSetWithEnd := fixtures{
+	valuesSingleSetWithEnd := fixtures{
 		name: "single set, with end",
-		documents: func() []*Document {
-			return []*Document{
+		vValues: func() []*VersionedValue {
+			return []*VersionedValue{
 				{
 					Key:            "A",
 					TxTimeStart:    t1,
@@ -1429,10 +1429,10 @@ func TestHistory(t *testing.T) {
 	}
 	// // 1 initial set and 1 set with later valid time updating score
 	// // this sets a TxTimeEnd for the initial record and creates 2 new ones
-	aDocsUpdated := fixtures{
+	valuesUpdated := fixtures{
 		name: "initial set, and then set with later valid time",
-		documents: func() []*Document {
-			return []*Document{
+		vValues: func() []*VersionedValue {
+			return []*VersionedValue{
 				{
 					Key:            "A",
 					TxTimeStart:    t1,
@@ -1460,10 +1460,10 @@ func TestHistory(t *testing.T) {
 			}
 		},
 	}
-	aDocsDeleted := fixtures{
+	valuesDeleted := fixtures{
 		name: "initial set, and then deletion with later valid time",
-		documents: func() []*Document {
-			return []*Document{
+		vValues: func() []*VersionedValue {
+			return []*VersionedValue{
 				{
 					Key:            "A",
 					TxTimeStart:    t1,
@@ -1489,7 +1489,7 @@ func TestHistory(t *testing.T) {
 		key               string
 		expectErrNotFound bool
 		expectErr         bool // this is exclusive of ErrNotFound. this is for unexepcted errors
-		expectDocuments   []*Document
+		expectValues      []*VersionedValue
 	}
 
 	testCaseSets := []struct {
@@ -1498,8 +1498,8 @@ func TestHistory(t *testing.T) {
 	}{
 		{
 			fixtures: fixtures{
-				name:      "empty db",
-				documents: func() []*Document { return nil },
+				name:    "empty db",
+				vValues: func() []*VersionedValue { return nil },
 			},
 			testCases: []testCase{
 				{
@@ -1510,12 +1510,12 @@ func TestHistory(t *testing.T) {
 			},
 		},
 		{
-			fixtures: aDocsSingleSet,
+			fixtures: valuesSingleSet,
 			testCases: []testCase{
 				{
 					desc: "basic - return 1 version",
 					key:  "A",
-					expectDocuments: []*Document{
+					expectValues: []*VersionedValue{
 						{
 							Key:            "A",
 							TxTimeStart:    t1,
@@ -1529,12 +1529,12 @@ func TestHistory(t *testing.T) {
 			},
 		},
 		{
-			fixtures: aDocsSingleSetWithEnd,
+			fixtures: valuesSingleSetWithEnd,
 			testCases: []testCase{
 				{
 					desc: "basic - return 1 version",
 					key:  "A",
-					expectDocuments: []*Document{
+					expectValues: []*VersionedValue{
 						{
 							Key:            "A",
 							TxTimeStart:    t1,
@@ -1548,12 +1548,12 @@ func TestHistory(t *testing.T) {
 			},
 		},
 		{
-			fixtures: aDocsUpdated,
+			fixtures: valuesUpdated,
 			testCases: []testCase{
 				{
 					desc: "return versions by descending end transaction time, descending end valid time",
 					key:  "A",
-					expectDocuments: []*Document{
+					expectValues: []*VersionedValue{
 						{
 							Key:            "A",
 							TxTimeStart:    t3,
@@ -1583,12 +1583,12 @@ func TestHistory(t *testing.T) {
 			},
 		},
 		{
-			fixtures: aDocsDeleted,
+			fixtures: valuesDeleted,
 			testCases: []testCase{
 				{
 					desc: "returns \"deleted\" versions",
 					key:  "A",
-					expectDocuments: []*Document{
+					expectValues: []*VersionedValue{
 						{
 							Key:            "A",
 							TxTimeStart:    t3,
@@ -1612,8 +1612,8 @@ func TestHistory(t *testing.T) {
 		{
 			fixtures: fixtures{
 				name: "version has later transaction time start, but earlier transaction time end",
-				documents: func() []*Document {
-					return []*Document{
+				vValues: func() []*VersionedValue {
+					return []*VersionedValue{
 						{
 							Key:            "A",
 							TxTimeStart:    t2,
@@ -1637,7 +1637,7 @@ func TestHistory(t *testing.T) {
 				{
 					desc: "return versions by descending end transaction time, descending end valid time",
 					key:  "A",
-					expectDocuments: []*Document{
+					expectValues: []*VersionedValue{
 						{
 							Key:            "A",
 							TxTimeStart:    t1,
@@ -1661,8 +1661,8 @@ func TestHistory(t *testing.T) {
 		{
 			fixtures: fixtures{
 				name: "multiple versions have nil end transaction time",
-				documents: func() []*Document {
-					return []*Document{
+				vValues: func() []*VersionedValue {
+					return []*VersionedValue{
 						{
 							Key:            "A",
 							TxTimeStart:    t1,
@@ -1686,7 +1686,7 @@ func TestHistory(t *testing.T) {
 				{
 					desc: "return versions by descending end transaction time, descending end valid time",
 					key:  "A",
-					expectDocuments: []*Document{
+					expectValues: []*VersionedValue{
 						{
 							Key:            "A",
 							TxTimeStart:    t2,
@@ -1713,7 +1713,7 @@ func TestHistory(t *testing.T) {
 		for _, tC := range s.testCases {
 			tC := tC
 			t.Run(fmt.Sprintf("%v: %v", s.fixtures.name, tC.desc), func(t *testing.T) {
-				db, err := memory.NewDB(s.fixtures.documents()...)
+				db, err := memory.NewDB(s.fixtures.vValues()...)
 				require.Nil(t, err)
 				ret, err := db.History(tC.key)
 				if tC.expectErrNotFound {
@@ -1725,7 +1725,7 @@ func TestHistory(t *testing.T) {
 					return
 				}
 				require.Nil(t, err)
-				assert.Equal(t, tC.expectDocuments, ret)
+				assert.Equal(t, tC.expectValues, ret)
 			})
 		}
 	}

--- a/memory/db_test.go
+++ b/memory/db_test.go
@@ -186,9 +186,9 @@ func TestGet(t *testing.T) {
 		documents func() []*Document
 	}
 
-	// 1 initial put
+	// 1 initial set
 	aDocsSingleSet := fixtures{
-		name: "single put, no end",
+		name: "single set, no end",
 		documents: func() []*Document {
 			return []*Document{
 				{
@@ -202,9 +202,9 @@ func TestGet(t *testing.T) {
 			}
 		},
 	}
-	// 1 initial put with a valid time end
+	// 1 initial set with a valid time end
 	aDocsSingleSetWithEnd := fixtures{
-		name: "single put, with end",
+		name: "single set, with end",
 		documents: func() []*Document {
 			return []*Document{
 				{
@@ -218,10 +218,10 @@ func TestGet(t *testing.T) {
 			}
 		},
 	}
-	// // 1 initial put and 1 put with later valid time updating score
+	// // 1 initial set and 1 set with later valid time updating score
 	// // this sets a TxTimeEnd for the initial record and creates 2 new ones
 	aDocsUpdated := fixtures{
-		name: "initial put, and then put with later valid time",
+		name: "initial set, and then set with later valid time",
 		documents: func() []*Document {
 			return []*Document{
 				{
@@ -252,7 +252,7 @@ func TestGet(t *testing.T) {
 		},
 	}
 	aDocsDeleted := fixtures{
-		name: "initial put, and then deletion with later valid time",
+		name: "initial set, and then deletion with later valid time",
 		documents: func() []*Document {
 			return []*Document{
 				{
@@ -634,7 +634,7 @@ func TestSet(t *testing.T) {
 			},
 			testCases: []testCase{
 				{
-					desc:  "basic put",
+					desc:  "basic set",
 					now:   &t1,
 					key:   "A",
 					value: "Old",
@@ -652,7 +652,7 @@ func TestSet(t *testing.T) {
 					},
 				},
 				{
-					desc:      "basic put with valid time",
+					desc:      "basic set with valid time",
 					now:       &t1,
 					key:       "A",
 					value:     "Old",
@@ -671,7 +671,7 @@ func TestSet(t *testing.T) {
 					},
 				},
 				{
-					desc:      "basic put with end valid time",
+					desc:      "basic set with end valid time",
 					now:       &t1,
 					key:       "A",
 					value:     "Old",
@@ -690,7 +690,7 @@ func TestSet(t *testing.T) {
 					},
 				},
 				{
-					desc:      "basic put with valid time and end valid time",
+					desc:      "basic set with valid time and end valid time",
 					now:       &t1,
 					key:       "A",
 					value:     "Old",
@@ -704,6 +704,24 @@ func TestSet(t *testing.T) {
 								ValidTimeStart: t0,
 								ValidTimeEnd:   &t3,
 								Value:          "Old",
+							},
+						},
+					},
+				},
+				{
+					desc:  "can set value of nil",
+					now:   &t1,
+					key:   "A",
+					value: nil,
+					findChecks: []findCheck{
+						{
+							expectDocument: &Document{
+								Key:            "A",
+								TxTimeStart:    t1,
+								TxTimeEnd:      nil,
+								ValidTimeStart: t1,
+								ValidTimeEnd:   nil,
+								Value:          nil,
 							},
 						},
 					},
@@ -759,7 +777,7 @@ func TestSet(t *testing.T) {
 			},
 			testCases: []testCase{
 				{
-					desc:  "basic put",
+					desc:  "basic set",
 					now:   &t3,
 					key:   "A",
 					value: "New",
@@ -801,7 +819,7 @@ func TestSet(t *testing.T) {
 					},
 				},
 				{
-					desc:      "put w/ valid time end. original record overhands on both sides",
+					desc:      "set w/ valid time end. original record overhands on both sides",
 					now:       &t4,
 					writeOpts: []WriteOpt{WithValidTime(t2), WithEndValidTime(t3)},
 					key:       "A",
@@ -857,7 +875,7 @@ func TestSet(t *testing.T) {
 					},
 				},
 				{
-					desc:      "put w/ valid time end. no overhang",
+					desc:      "set w/ valid time end. no overhang",
 					now:       &t4,
 					writeOpts: []WriteOpt{WithValidTime(t1)},
 					key:       "A",
@@ -924,7 +942,7 @@ func TestSet(t *testing.T) {
 			},
 			testCases: []testCase{
 				{
-					desc:      "put overlaps multiple versions",
+					desc:      "set overlaps multiple versions",
 					now:       &t4,
 					key:       "A",
 					writeOpts: []WriteOpt{WithValidTime(t2), WithEndValidTime(t4)},
@@ -1157,7 +1175,7 @@ func TestDelete(t *testing.T) {
 					},
 				},
 				{
-					desc:      "put w/ valid time end. original record overhands on both sides",
+					desc:      "set w/ valid time end. original record overhands on both sides",
 					now:       &t4,
 					writeOpts: []WriteOpt{WithValidTime(t2), WithEndValidTime(t3)},
 					key:       "A",
@@ -1205,7 +1223,7 @@ func TestDelete(t *testing.T) {
 					},
 				},
 				{
-					desc:      "put w/ valid time end. no overhang",
+					desc:      "set w/ valid time end. no overhang",
 					now:       &t4,
 					writeOpts: []WriteOpt{WithValidTime(t1)},
 					key:       "A",
@@ -1264,7 +1282,7 @@ func TestDelete(t *testing.T) {
 			},
 			testCases: []testCase{
 				{
-					desc:      "put overlaps multiple versions",
+					desc:      "set overlaps multiple versions",
 					now:       &t4,
 					key:       "A",
 					writeOpts: []WriteOpt{WithValidTime(t2), WithEndValidTime(t4)},
@@ -1377,9 +1395,9 @@ func TestHistory(t *testing.T) {
 		documents func() []*Document
 	}
 
-	// 1 initial put
+	// 1 initial set
 	aDocsSingleSet := fixtures{
-		name: "single put, no end",
+		name: "single set, no end",
 		documents: func() []*Document {
 			return []*Document{
 				{
@@ -1393,9 +1411,9 @@ func TestHistory(t *testing.T) {
 			}
 		},
 	}
-	// 1 initial put with a valid time end
+	// 1 initial set with a valid time end
 	aDocsSingleSetWithEnd := fixtures{
-		name: "single put, with end",
+		name: "single set, with end",
 		documents: func() []*Document {
 			return []*Document{
 				{
@@ -1409,10 +1427,10 @@ func TestHistory(t *testing.T) {
 			}
 		},
 	}
-	// // 1 initial put and 1 put with later valid time updating score
+	// // 1 initial set and 1 set with later valid time updating score
 	// // this sets a TxTimeEnd for the initial record and creates 2 new ones
 	aDocsUpdated := fixtures{
-		name: "initial put, and then put with later valid time",
+		name: "initial set, and then set with later valid time",
 		documents: func() []*Document {
 			return []*Document{
 				{
@@ -1443,7 +1461,7 @@ func TestHistory(t *testing.T) {
 		},
 	}
 	aDocsDeleted := fixtures{
-		name: "initial put, and then deletion with later valid time",
+		name: "initial set, and then deletion with later valid time",
 		documents: func() []*Document {
 			return []*Document{
 				{

--- a/memory/db_test.go
+++ b/memory/db_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/elh/bitemporal"
-	"github.com/elh/bitemporal/memory"
+	. "github.com/elh/bitempura"
+	"github.com/elh/bitempura/memory"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/memory/db_test.go
+++ b/memory/db_test.go
@@ -75,7 +75,7 @@ func TestConstructor(t *testing.T) {
 				documents: func() []*Document {
 					return []*Document{
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t1,
 							TxTimeEnd:      nil,
 							ValidTimeStart: t1,
@@ -83,7 +83,7 @@ func TestConstructor(t *testing.T) {
 							Attributes:     Attributes{"dimensions": 1},
 						},
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t2,
 							TxTimeEnd:      &t3,
 							ValidTimeStart: t2,
@@ -105,7 +105,7 @@ func TestConstructor(t *testing.T) {
 				documents: func() []*Document {
 					return []*Document{
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t1,
 							TxTimeEnd:      &t2,
 							ValidTimeStart: t2,
@@ -113,7 +113,7 @@ func TestConstructor(t *testing.T) {
 							Attributes:     Attributes{"dimensions": 1},
 						},
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t2,
 							TxTimeEnd:      nil,
 							ValidTimeStart: t1,
@@ -135,7 +135,7 @@ func TestConstructor(t *testing.T) {
 				documents: func() []*Document {
 					return []*Document{
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t1,
 							TxTimeEnd:      nil,
 							ValidTimeStart: t1,
@@ -143,7 +143,7 @@ func TestConstructor(t *testing.T) {
 							Attributes:     Attributes{"dimensions": 1},
 						},
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t2,
 							TxTimeEnd:      &t3,
 							ValidTimeStart: t2,
@@ -192,7 +192,7 @@ func TestGet(t *testing.T) {
 		documents: func() []*Document {
 			return []*Document{
 				{
-					ID:             "A",
+					Key:            "A",
 					TxTimeStart:    t1,
 					TxTimeEnd:      nil,
 					ValidTimeStart: t1,
@@ -208,7 +208,7 @@ func TestGet(t *testing.T) {
 		documents: func() []*Document {
 			return []*Document{
 				{
-					ID:             "A",
+					Key:            "A",
 					TxTimeStart:    t1,
 					TxTimeEnd:      nil,
 					ValidTimeStart: t1,
@@ -225,7 +225,7 @@ func TestGet(t *testing.T) {
 		documents: func() []*Document {
 			return []*Document{
 				{
-					ID:             "A",
+					Key:            "A",
 					TxTimeStart:    t1,
 					TxTimeEnd:      &t3,
 					ValidTimeStart: t1,
@@ -233,7 +233,7 @@ func TestGet(t *testing.T) {
 					Attributes:     put1Attrs,
 				},
 				{
-					ID:             "A",
+					Key:            "A",
 					TxTimeStart:    t3,
 					TxTimeEnd:      nil,
 					ValidTimeStart: t1,
@@ -241,7 +241,7 @@ func TestGet(t *testing.T) {
 					Attributes:     put1Attrs,
 				},
 				{
-					ID:             "A",
+					Key:            "A",
 					TxTimeStart:    t3,
 					TxTimeEnd:      nil,
 					ValidTimeStart: t3,
@@ -256,7 +256,7 @@ func TestGet(t *testing.T) {
 		documents: func() []*Document {
 			return []*Document{
 				{
-					ID:             "A",
+					Key:            "A",
 					TxTimeStart:    t1,
 					TxTimeEnd:      &t3,
 					ValidTimeStart: t1,
@@ -264,7 +264,7 @@ func TestGet(t *testing.T) {
 					Attributes:     put1Attrs,
 				},
 				{
-					ID:             "A",
+					Key:            "A",
 					TxTimeStart:    t3,
 					TxTimeEnd:      nil,
 					ValidTimeStart: t1,
@@ -464,7 +464,7 @@ func TestList(t *testing.T) {
 	}
 
 	aDoc := &Document{
-		ID:             "A",
+		Key:            "A",
 		TxTimeStart:    t1,
 		TxTimeEnd:      nil,
 		ValidTimeStart: t1,
@@ -482,7 +482,7 @@ func TestList(t *testing.T) {
 		},
 	}
 	bDoc := &Document{
-		ID:             "B",
+		Key:            "B",
 		TxTimeStart:    t1,
 		TxTimeEnd:      &t3,
 		ValidTimeStart: t1,
@@ -492,7 +492,7 @@ func TestList(t *testing.T) {
 		},
 	}
 	bDocUpdate1 := &Document{
-		ID:             "B",
+		Key:            "B",
 		TxTimeStart:    t3,
 		TxTimeEnd:      nil,
 		ValidTimeStart: t1,
@@ -502,7 +502,7 @@ func TestList(t *testing.T) {
 		},
 	}
 	bDocUpdate2 := &Document{
-		ID:             "B",
+		Key:            "B",
 		TxTimeStart:    t3,
 		TxTimeEnd:      nil,
 		ValidTimeStart: t3,
@@ -593,16 +593,16 @@ func TestList(t *testing.T) {
 				if len(tC.expectDocuments) == 0 {
 					return
 				}
-				assert.Equal(t, sortDocumentsByID(tC.expectDocuments), sortDocumentsByID(ret))
+				assert.Equal(t, sortDocumentsByKey(tC.expectDocuments), sortDocumentsByKey(ret))
 			})
 		}
 	}
 }
 
-func sortDocumentsByID(ds []*Document) []*Document {
+func sortDocumentsByKey(ds []*Document) []*Document {
 	out := make([]*Document, len(ds))
 	copy(out, ds)
-	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
 	return out
 }
 
@@ -649,7 +649,7 @@ func TestSet(t *testing.T) {
 					findChecks: []findCheck{
 						{
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      nil,
 								ValidTimeStart: t1,
@@ -670,7 +670,7 @@ func TestSet(t *testing.T) {
 					findChecks: []findCheck{
 						{
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      nil,
 								ValidTimeStart: t0,
@@ -691,7 +691,7 @@ func TestSet(t *testing.T) {
 					findChecks: []findCheck{
 						{
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      nil,
 								ValidTimeStart: t1,
@@ -712,7 +712,7 @@ func TestSet(t *testing.T) {
 					findChecks: []findCheck{
 						{
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      nil,
 								ValidTimeStart: t0,
@@ -763,7 +763,7 @@ func TestSet(t *testing.T) {
 				documents: func() []*Document {
 					return []*Document{
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t1,
 							TxTimeEnd:      nil,
 							ValidTimeStart: t1,
@@ -784,7 +784,7 @@ func TestSet(t *testing.T) {
 					findChecks: []findCheck{
 						{
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t3,
 								TxTimeEnd:      nil,
 								ValidTimeStart: t3,
@@ -798,7 +798,7 @@ func TestSet(t *testing.T) {
 						{
 							readOpts: []ReadOpt{AsOfValidTime(t2)},
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t3,
 								TxTimeEnd:      nil,
 								ValidTimeStart: t1,
@@ -812,7 +812,7 @@ func TestSet(t *testing.T) {
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t2)},
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      &t3,
 								ValidTimeStart: t1,
@@ -834,7 +834,7 @@ func TestSet(t *testing.T) {
 						// query as of now for valid time and transaction time. change not visible
 						{
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
 								ValidTimeStart: t3,
@@ -848,7 +848,7 @@ func TestSet(t *testing.T) {
 						{
 							readOpts: []ReadOpt{AsOfValidTime(t1)},
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
 								ValidTimeStart: t1,
@@ -862,7 +862,7 @@ func TestSet(t *testing.T) {
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t2)},
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      &t4,
 								ValidTimeStart: t1,
@@ -876,7 +876,7 @@ func TestSet(t *testing.T) {
 						{
 							readOpts: []ReadOpt{AsOfValidTime(t2), AsOfTransactionTime(t5)},
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
 								ValidTimeStart: t2,
@@ -898,7 +898,7 @@ func TestSet(t *testing.T) {
 						// query as of now for valid time and transaction time. change visible
 						{
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
 								ValidTimeStart: t1,
@@ -912,7 +912,7 @@ func TestSet(t *testing.T) {
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t2)},
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      &t4,
 								ValidTimeStart: t1,
@@ -932,7 +932,7 @@ func TestSet(t *testing.T) {
 				documents: func() []*Document {
 					return []*Document{
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t1,
 							TxTimeEnd:      &t3,
 							ValidTimeStart: t1,
@@ -940,7 +940,7 @@ func TestSet(t *testing.T) {
 							Attributes:     Attributes{"COUNT": 1},
 						},
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t3,
 							TxTimeEnd:      nil,
 							ValidTimeStart: t1,
@@ -948,7 +948,7 @@ func TestSet(t *testing.T) {
 							Attributes:     Attributes{"COUNT": 1},
 						},
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t3,
 							TxTimeEnd:      nil,
 							ValidTimeStart: t3,
@@ -970,7 +970,7 @@ func TestSet(t *testing.T) {
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t5)},
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
 								ValidTimeStart: t4,
@@ -984,7 +984,7 @@ func TestSet(t *testing.T) {
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t5), AsOfValidTime(t1)},
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
 								ValidTimeStart: t1,
@@ -998,7 +998,7 @@ func TestSet(t *testing.T) {
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t5), AsOfValidTime(t3)},
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
 								ValidTimeStart: t2,
@@ -1012,7 +1012,7 @@ func TestSet(t *testing.T) {
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t3), AsOfValidTime(t2)},
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t3,
 								TxTimeEnd:      &t4,
 								ValidTimeStart: t1,
@@ -1026,7 +1026,7 @@ func TestSet(t *testing.T) {
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t3), AsOfValidTime(t4)},
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t3,
 								TxTimeEnd:      &t4,
 								ValidTimeStart: t3,
@@ -1040,7 +1040,7 @@ func TestSet(t *testing.T) {
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t2), AsOfValidTime(t2)},
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      &t3,
 								ValidTimeStart: t1,
@@ -1138,7 +1138,7 @@ func TestDelete(t *testing.T) {
 				documents: func() []*Document {
 					return []*Document{
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t1,
 							TxTimeEnd:      nil,
 							ValidTimeStart: t1,
@@ -1184,7 +1184,7 @@ func TestDelete(t *testing.T) {
 						{
 							readOpts: []ReadOpt{AsOfValidTime(t2)},
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t3,
 								TxTimeEnd:      nil,
 								ValidTimeStart: t1,
@@ -1198,7 +1198,7 @@ func TestDelete(t *testing.T) {
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t2)},
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      &t3,
 								ValidTimeStart: t1,
@@ -1219,7 +1219,7 @@ func TestDelete(t *testing.T) {
 						// query as of now for valid time and transaction time. change not visible
 						{
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
 								ValidTimeStart: t3,
@@ -1233,7 +1233,7 @@ func TestDelete(t *testing.T) {
 						{
 							readOpts: []ReadOpt{AsOfValidTime(t1)},
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
 								ValidTimeStart: t1,
@@ -1247,7 +1247,7 @@ func TestDelete(t *testing.T) {
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t2)},
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      &t4,
 								ValidTimeStart: t1,
@@ -1278,7 +1278,7 @@ func TestDelete(t *testing.T) {
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t2)},
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      &t4,
 								ValidTimeStart: t1,
@@ -1298,7 +1298,7 @@ func TestDelete(t *testing.T) {
 				documents: func() []*Document {
 					return []*Document{
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t1,
 							TxTimeEnd:      &t3,
 							ValidTimeStart: t1,
@@ -1306,7 +1306,7 @@ func TestDelete(t *testing.T) {
 							Attributes:     Attributes{"COUNT": 1},
 						},
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t3,
 							TxTimeEnd:      nil,
 							ValidTimeStart: t1,
@@ -1314,7 +1314,7 @@ func TestDelete(t *testing.T) {
 							Attributes:     Attributes{"COUNT": 1},
 						},
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t3,
 							TxTimeEnd:      nil,
 							ValidTimeStart: t3,
@@ -1335,7 +1335,7 @@ func TestDelete(t *testing.T) {
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t5)},
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
 								ValidTimeStart: t4,
@@ -1349,7 +1349,7 @@ func TestDelete(t *testing.T) {
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t5), AsOfValidTime(t1)},
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t4,
 								TxTimeEnd:      nil,
 								ValidTimeStart: t1,
@@ -1368,7 +1368,7 @@ func TestDelete(t *testing.T) {
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t3), AsOfValidTime(t2)},
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t3,
 								TxTimeEnd:      &t4,
 								ValidTimeStart: t1,
@@ -1382,7 +1382,7 @@ func TestDelete(t *testing.T) {
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t3), AsOfValidTime(t4)},
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t3,
 								TxTimeEnd:      &t4,
 								ValidTimeStart: t3,
@@ -1396,7 +1396,7 @@ func TestDelete(t *testing.T) {
 						{
 							readOpts: []ReadOpt{AsOfTransactionTime(t2), AsOfValidTime(t2)},
 							expectDocument: &Document{
-								ID:             "A",
+								Key:            "A",
 								TxTimeStart:    t1,
 								TxTimeEnd:      &t3,
 								ValidTimeStart: t1,
@@ -1457,7 +1457,7 @@ func TestHistory(t *testing.T) {
 		documents: func() []*Document {
 			return []*Document{
 				{
-					ID:             "A",
+					Key:            "A",
 					TxTimeStart:    t1,
 					TxTimeEnd:      nil,
 					ValidTimeStart: t1,
@@ -1473,7 +1473,7 @@ func TestHistory(t *testing.T) {
 		documents: func() []*Document {
 			return []*Document{
 				{
-					ID:             "A",
+					Key:            "A",
 					TxTimeStart:    t1,
 					TxTimeEnd:      nil,
 					ValidTimeStart: t1,
@@ -1490,7 +1490,7 @@ func TestHistory(t *testing.T) {
 		documents: func() []*Document {
 			return []*Document{
 				{
-					ID:             "A",
+					Key:            "A",
 					TxTimeStart:    t1,
 					TxTimeEnd:      &t3,
 					ValidTimeStart: t1,
@@ -1498,7 +1498,7 @@ func TestHistory(t *testing.T) {
 					Attributes:     put1Attrs,
 				},
 				{
-					ID:             "A",
+					Key:            "A",
 					TxTimeStart:    t3,
 					TxTimeEnd:      nil,
 					ValidTimeStart: t1,
@@ -1506,7 +1506,7 @@ func TestHistory(t *testing.T) {
 					Attributes:     put1Attrs,
 				},
 				{
-					ID:             "A",
+					Key:            "A",
 					TxTimeStart:    t3,
 					TxTimeEnd:      nil,
 					ValidTimeStart: t3,
@@ -1521,7 +1521,7 @@ func TestHistory(t *testing.T) {
 		documents: func() []*Document {
 			return []*Document{
 				{
-					ID:             "A",
+					Key:            "A",
 					TxTimeStart:    t1,
 					TxTimeEnd:      &t3,
 					ValidTimeStart: t1,
@@ -1529,7 +1529,7 @@ func TestHistory(t *testing.T) {
 					Attributes:     put1Attrs,
 				},
 				{
-					ID:             "A",
+					Key:            "A",
 					TxTimeStart:    t3,
 					TxTimeEnd:      nil,
 					ValidTimeStart: t1,
@@ -1573,7 +1573,7 @@ func TestHistory(t *testing.T) {
 					id:   "A",
 					expectDocuments: []*Document{
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t1,
 							TxTimeEnd:      nil,
 							ValidTimeStart: t1,
@@ -1592,7 +1592,7 @@ func TestHistory(t *testing.T) {
 					id:   "A",
 					expectDocuments: []*Document{
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t1,
 							TxTimeEnd:      nil,
 							ValidTimeStart: t1,
@@ -1611,7 +1611,7 @@ func TestHistory(t *testing.T) {
 					id:   "A",
 					expectDocuments: []*Document{
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t3,
 							TxTimeEnd:      nil,
 							ValidTimeStart: t3,
@@ -1619,7 +1619,7 @@ func TestHistory(t *testing.T) {
 							Attributes:     put2Attrs,
 						},
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t3,
 							TxTimeEnd:      nil,
 							ValidTimeStart: t1,
@@ -1627,7 +1627,7 @@ func TestHistory(t *testing.T) {
 							Attributes:     put1Attrs,
 						},
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t1,
 							TxTimeEnd:      &t3,
 							ValidTimeStart: t1,
@@ -1646,7 +1646,7 @@ func TestHistory(t *testing.T) {
 					id:   "A",
 					expectDocuments: []*Document{
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t3,
 							TxTimeEnd:      nil,
 							ValidTimeStart: t1,
@@ -1654,7 +1654,7 @@ func TestHistory(t *testing.T) {
 							Attributes:     put1Attrs,
 						},
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t1,
 							TxTimeEnd:      &t3,
 							ValidTimeStart: t1,
@@ -1671,7 +1671,7 @@ func TestHistory(t *testing.T) {
 				documents: func() []*Document {
 					return []*Document{
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t2,
 							TxTimeEnd:      &t3,
 							ValidTimeStart: t3,
@@ -1679,7 +1679,7 @@ func TestHistory(t *testing.T) {
 							Attributes:     put1Attrs,
 						},
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t1,
 							TxTimeEnd:      nil,
 							ValidTimeStart: t1,
@@ -1695,7 +1695,7 @@ func TestHistory(t *testing.T) {
 					id:   "A",
 					expectDocuments: []*Document{
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t1,
 							TxTimeEnd:      nil,
 							ValidTimeStart: t1,
@@ -1703,7 +1703,7 @@ func TestHistory(t *testing.T) {
 							Attributes:     put2Attrs,
 						},
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t2,
 							TxTimeEnd:      &t3,
 							ValidTimeStart: t3,
@@ -1720,7 +1720,7 @@ func TestHistory(t *testing.T) {
 				documents: func() []*Document {
 					return []*Document{
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t1,
 							TxTimeEnd:      nil,
 							ValidTimeStart: t1,
@@ -1728,7 +1728,7 @@ func TestHistory(t *testing.T) {
 							Attributes:     put2Attrs,
 						},
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t2,
 							TxTimeEnd:      nil,
 							ValidTimeStart: t3,
@@ -1744,7 +1744,7 @@ func TestHistory(t *testing.T) {
 					id:   "A",
 					expectDocuments: []*Document{
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t2,
 							TxTimeEnd:      nil,
 							ValidTimeStart: t3,
@@ -1752,7 +1752,7 @@ func TestHistory(t *testing.T) {
 							Attributes:     put1Attrs,
 						},
 						{
-							ID:             "A",
+							Key:            "A",
 							TxTimeStart:    t1,
 							TxTimeEnd:      nil,
 							ValidTimeStart: t1,

--- a/memory/doc.go
+++ b/memory/doc.go
@@ -1,2 +1,2 @@
-// Package memory contains in memory reference implementation of bitempura.DB
+// Package memory contains in-memory reference implementation of bitempura.DB
 package memory

--- a/memory/doc.go
+++ b/memory/doc.go
@@ -1,2 +1,2 @@
-// Package memory contains in memory reference implementation of bitemporal.DB
+// Package memory contains in memory reference implementation of bitempura.DB
 package memory


### PR DESCRIPTION
* rename to something less generic
* update language to "key-value" database so that it more accurately represents where it is. Retract some of the "toy" language for now

- [x] update to key-value style. 
    - [x] rename `id` to `key`. 
    - [x] remove `Attributes` type and replace with a `type Value interface{}` type? 
        * maybe try go generics in a separate cache project(!)
    - [x] rename `Find`/`Put` to `Get`/`Set`
- [x] decide what to do about `Document`... I guess it should just become "VersionedValue" and be the only place that these times are externalized.
    - [x] Add model to README
    * consider a version of the interfaces that opts in to listing version information?